### PR TITLE
Fix build errors on Python 3.11 due to PEP-670

### DIFF
--- a/python/tensorstore/bfloat16.cc
+++ b/python/tensorstore/bfloat16.cc
@@ -771,7 +771,7 @@ bool Initialize() {
   NPyBfloat16_ArrFuncs.argmax = NPyBfloat16_ArgMaxFunc;
   NPyBfloat16_ArrFuncs.argmin = NPyBfloat16_ArgMinFunc;
 
-  Py_TYPE(&NPyBfloat16_Descr) = &PyArrayDescr_Type;
+  Py_SET_TYPE(&NPyBfloat16_Descr, &PyArrayDescr_Type);
   npy_bfloat16 = PyArray_RegisterDataType(&NPyBfloat16_Descr);
   bfloat16_type_ptr = &bfloat16_type;
   if (npy_bfloat16 < 0) {


### PR DESCRIPTION
On Python 3.11, tensorstore fails to build with the following error:

```
python/tensorstore/bfloat16.cc:774:31: error: expression is not assignable
    Py_TYPE(&NPyBfloat16_Descr) = &PyArrayDescr_Type;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  1 error generated.
```

As per [PEP-670], `Py_TYPE` is no longer a macro since python 3.11,
but now is a static inline function; we should instead use `Py_SET_TYPE`
to avoid the compilation error.

With this commit tensorstore can be built from source on Python 3.11.

[PEP-670]: https://peps.python.org/pep-0670/

Fixes #70
