### PR TITLE
Fix Typo: staic -> static

### DIFF
--- a/tensorstore/driver/stack/index.rst
+++ b/tensorstore/driver/stack/index.rst
@@ -4,7 +4,7 @@
 The ``stack`` driver specifies a TensorStore backed by a sequence of layered
 drivers, where each underlying layer describes it's bounds via a transform.
 
-- The TensorStore for a stack driver has staic bounds, which may be derived
+- The TensorStore for a stack driver has static bounds, which may be derived
   from the underlying :json:schema:`~driver/stack.layers`
 
 - Reading is supported if the :json:schema:`~driver/stack.layers` TensorStore


### PR DESCRIPTION
Fix typo in the stack driver documentation.