### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,9 @@ jobs:
       shell: bash # For ~ expansion
     - name: Get pip cache dir
       id: pip-cache
+      shell: bash
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}


### PR DESCRIPTION
## Description

Resolve  #95 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: |
  echo "::set-output name=dir::$(pip cache dir)"
```

**TO-BE**

```yml
shell: bash # for windows
run: |
  echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
```