### PR TITLE
Add BAZEL_PATH environment variable

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -457,6 +457,11 @@ def execute_bazel(bazel_path, argv):
 
 
 def get_bazel_path():
+    
+    # If Bazel already exists, skip Bazelisk wrapper.
+    if "BAZEL_PATH" in os.environ:
+        return os.environ["BAZEL_PATH"]
+
     bazelisk_directory = get_bazelisk_directory()
     maybe_makedirs(bazelisk_directory)
 


### PR DESCRIPTION
Trying to make `tensorstore` work without downloading Bazel through Bazelisk, for sandboxed builds without a writeable $HOME directory.