### PR TITLE
docs: fix URL references for neuroglancer

### DIFF
--- a/tensorstore/driver/neuroglancer_precomputed/index.rst
+++ b/tensorstore/driver/neuroglancer_precomputed/index.rst
@@ -3,7 +3,7 @@
 ``neuroglancer_precomputed`` Driver
 ===================================
 
-The ``neuroglancer_precomputed`` driver provides access to `Neuroglancer Precomputed format <https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed>`_ volumes backed by any supported :ref:`key_value_store`.  It supports reading, writing, and creating new volumes.
+The ``neuroglancer_precomputed`` driver provides access to `Neuroglancer Precomputed format <https://github.com/google/neuroglancer/tree/master/src/datasource/precomputed>`_ volumes backed by any supported :ref:`key_value_store`.  It supports reading, writing, and creating new volumes.
 
 Multiscale volumes are supported, but each scale must be opened individually.
 

--- a/tensorstore/driver/neuroglancer_precomputed/metadata.h
+++ b/tensorstore/driver/neuroglancer_precomputed/metadata.h
@@ -19,7 +19,7 @@
 /// Metadata handling for the Neuroglancer precomputed format.
 ///
 /// Refer to the specification here:
-/// https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed
+/// https://github.com/google/neuroglancer/tree/master/src/datasource/precomputed
 
 #include <stddef.h>
 #include <stdint.h>

--- a/tensorstore/driver/neuroglancer_precomputed/schema.yml
+++ b/tensorstore/driver/neuroglancer_precomputed/schema.yml
@@ -24,7 +24,7 @@ allOf:
       description: |-
         Specifies the scale-independent metadata of a new volume exactly as in
         the `info file
-        <https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed#info-json-file-specification>`_,
+        <https://github.com/google/neuroglancer/tree/master/src/datasource/precomputed#info-json-file-specification>`_,
         except that not all members are required.  Required when creating a new
         multiscale volume.  When opening an existing volume or creating a new
         scale within an existing multiscale volume, specifies constraints on the
@@ -58,7 +58,7 @@ allOf:
       title: Per-scale metadata.
       description: |-
         Specifies the per-scale metadata of a new volume as in the `info file
-        <https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed#info-json-file-specification>`_,
+        <https://github.com/google/neuroglancer/tree/master/src/datasource/precomputed#info-json-file-specification>`_,
         except that not all members are required, and the `.chunk_size` member
         for specifying a single chunk size takes the place of the
         :literal:`chunk_sizes` member in the :file:`info` file.  Required when creating a
@@ -157,9 +157,9 @@ allOf:
             - type: 'null'
             description: |-
               Specifies to use the `unsharded
-              <https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed#unsharded-chunk-storage>`_
+              <https://github.com/google/neuroglancer/tree/master/src/datasource/precomputed#unsharded-chunk-storage>`_
               (indicated by ``null``) or `sharded
-              <https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed#sharded-chunk-storage>`_
+              <https://github.com/google/neuroglancer/tree/master/src/datasource/precomputed#sharded-chunk-storage>`_
               format.  When creating a new scale, if not specified, the unsharded
               format is used.
 definitions:

--- a/tensorstore/kvstore/neuroglancer_uint64_sharded/index.rst
+++ b/tensorstore/kvstore/neuroglancer_uint64_sharded/index.rst
@@ -5,7 +5,7 @@
 
 The ``neuroglancer_uint64_sharded`` driver implements support for the
 `Neuroglancer Precomputed sharded format
-<https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed/sharded.md>`_
+<https://github.com/google/neuroglancer/tree/master/src/datasource/precomputed/sharded.md>`_
 on top of a base key-value store.
 
 Within the key-value store interface, which uses strings as keys, the uint64

--- a/tensorstore/kvstore/neuroglancer_uint64_sharded/uint64_sharded_decoder.h
+++ b/tensorstore/kvstore/neuroglancer_uint64_sharded/uint64_sharded_decoder.h
@@ -19,7 +19,7 @@
 /// Support for decoding the neuroglancer_uint64_sharded_v1 format.
 ///
 /// See description of format here:
-/// https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed#sharded-format
+/// https://github.com/google/neuroglancer/tree/master/src/datasource/precomputed#sharded-format
 
 #include <optional>
 #include <string_view>

--- a/tensorstore/kvstore/neuroglancer_uint64_sharded/uint64_sharded_encoder.h
+++ b/tensorstore/kvstore/neuroglancer_uint64_sharded/uint64_sharded_encoder.h
@@ -22,7 +22,7 @@
 /// arbitrary keys with only 3 reads.
 ///
 /// See description of format here:
-/// https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed#sharded-format
+/// https://github.com/google/neuroglancer/tree/master/src/datasource/precomputed#sharded-format
 
 #include <stdint.h>
 
@@ -42,14 +42,14 @@ namespace neuroglancer_uint64_sharded {
 /// Encodes a minishard index.
 ///
 /// The format is described here:
-/// https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed#minishard-index-format
+/// https://github.com/google/neuroglancer/tree/master/src/datasource/precomputed#minishard-index-format
 absl::Cord EncodeMinishardIndex(
     span<const MinishardIndexEntry> minishard_index);
 
 /// Encodes a shard index.
 ///
 /// The format is described here:
-/// https://github.com/google/neuroglancer/tree/master/src/neuroglancer/datasource/precomputed#shardindex-index-file-format
+/// https://github.com/google/neuroglancer/tree/master/src/datasource/precomputed#shardindex-index-file-format
 absl::Cord EncodeShardIndex(span<const ShardIndexEntry> shard_index);
 
 /// Class that may be used to sequentially encode a single shard.


### PR DESCRIPTION
Neuroglancer recently renamed `src/neuroglancer` to `src/` breaking these links. This PR fixes them. 

Note: The URLs with fragments (e.g. `#sharded-format`) still don't actually point to any element on the readme, but I think that predates the rename. Now they at least resolve correctly to the readme.