### PR TITLE
Fix bazel_to_cmake expand_template if parent directory does not exist

### DIFF
--- a/tools/cmake/bazel_to_cmake/bzl_library/expand_template.py
+++ b/tools/cmake/bazel_to_cmake/bzl_library/expand_template.py
@@ -29,7 +29,9 @@ def expand_template(out: str, template: str, substitutions: str):
   if subs:
     pattern = '|'.join(re.escape(key) for key in subs.keys())
     text = re.sub(pattern, lambda m: subs[m.group(0)], text)
-  pathlib.Path(out).write_text(text, encoding='utf-8')
+  path = pathlib.Path(out)
+  path.parent.mkdir(parents=True, exist_ok=True)
+  path.write_text(text, encoding='utf-8')
 
 
 def main():


### PR DESCRIPTION
This fixes `expand_template` in `bazel_to_cmake` so that it creates the parent directory of the output if it does not exist.

This partially fixes a cmake-based build for me, which otherwise errors as below:
```
Traceback (most recent call last):
  File "/home/lachy/dev/tensorstore/tools/cmake/bazel_to_cmake/bzl_library/expand_template.py", line 50, in <module>
    main()
  File "/home/lachy/dev/tensorstore/tools/cmake/bazel_to_cmake/bzl_library/expand_template.py", line 44, in main
    expand_template(
  File "/home/lachy/dev/tensorstore/tools/cmake/bazel_to_cmake/bzl_library/expand_template.py", line 32, in expand_template
    pathlib.Path(out).write_text(text, encoding='utf-8')
  File "/usr/lib/python3.11/pathlib.py", line 1079, in write_text
    with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/pathlib.py", line 1045, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/lachy/dev/tensorstore/build/_deps/nghttp2-build/lib/includes/nghttp2/nghttp2ver.h'
```