### PR TITLE
Enable grpc_kvstore for building

### DIFF
--- a/tensorstore/kvstore/BUILD
+++ b/tensorstore/kvstore/BUILD
@@ -33,7 +33,7 @@ DRIVERS = DRIVER_DOCS + [
     "gcs_http",
 ]
 
-EXTRA_DRIVER_TARGETS = []
+EXTRA_DRIVER_TARGETS = ["//tensorstore/kvstore/grpc:grpc_kvstore"]
 
 tensorstore_cc_library(
     name = "all_drivers",


### PR DESCRIPTION
Hi!

I am working on integrating tensorstore with [YTsaurus](https://github.com/ytsaurus/ytsaurus) as an underlying storage. 
In order to obtain the PoC I used the grpc_kvstore implementation of kvstore. It looks like this implementation is not currently considered "stable" or "officially supported", which is perfectly ok for me as our server-side implementation is also fresh and rapidly changing.

Still, not being able to use it with official pypi package of tensorstore is not very convenient as we have to provide patched version of tensorstore package with the only difference from this PR. What do you think about enabling use of this kvstore (possibly, with a number of disclaimers about being experimental and unstable)?

If you agree on this, we would be glad to announce (at some point of time) that YTsaurus provides integration with tensorstore via a certain grpc service. It may then happen that I'll be bringing more PRs extending the functionality of grpc_kvstore, as now it seems that it does not cover all the functionality from the internal kvstore [interface](https://github.com/google/tensorstore/blob/master/tensorstore/kvstore/operations.h).

Cheers,
Maxim.