### PR TITLE
Support streaming in tsgrpc kvstore driver.

### DIFF
--- a/tensorstore/kvstore/tsgrpc/kvstore.proto
+++ b/tensorstore/kvstore/tsgrpc/kvstore.proto
@@ -24,10 +24,10 @@ import "tensorstore/kvstore/tsgrpc/common.proto";
 // Proto-api for a remote key-value store
 service KvStoreService {
   /// Attempts to read the specified key.
-  rpc Read(ReadRequest) returns (ReadResponse);
+  rpc Read(ReadRequest) returns (stream ReadResponse);
 
   /// Performs an optionally-conditional write.
-  rpc Write(WriteRequest) returns (WriteResponse);
+  rpc Write(stream WriteRequest) returns (WriteResponse);
 
   /// Performs an optionally-conditional delete.
   rpc Delete(DeleteRequest) returns (DeleteResponse);
@@ -41,6 +41,8 @@ service KvStoreService {
 /// See tensorstore/kvstore/operations.h
 ///   kvstore::ReadOptions
 message ReadRequest {
+  // All fields except `value` are meaningful only for the first response message in the stream.
+
   bytes key = 1;
 
   /// The read is aborted if the generation associated with the stored `key`
@@ -94,7 +96,9 @@ message ReadResponse {
   }
   State state = 3;
 
-  bytes value = 4 [ctype = CORD];
+  /// Next part of the value. The actual value in the remote storage is the concatenation
+  /// of all parts in the response stream.
+  bytes value_part = 4 [ctype = CORD];
 }
 
 /// See tensorstore/kvstore/operations.h
@@ -112,7 +116,9 @@ message WriteRequest {
   ///   condition that the `key` does not have an existing value.
   bytes generation_if_equal = 2;
 
-  bytes value = 3 [ctype = CORD];
+  /// Next part of the value. The actual value to be written is the concatenation
+  /// of all parts in the response stream.
+  bytes value_part = 3 [ctype = CORD];
 }
 
 message WriteResponse {

--- a/tensorstore/kvstore/tsgrpc/kvstore_server.h
+++ b/tensorstore/kvstore/tsgrpc/kvstore_server.h
@@ -61,6 +61,9 @@ class KvStoreServer {
 
     /// Underlying kvstore used by the server.
     kvstore::Spec base;
+
+    /// Maximum number of bytes that can be sent in a single value part of a read response.
+    uint32_t max_sent_part_bytes;
   };
 
   /// Starts the kvstore server server.

--- a/tensorstore/kvstore/tsgrpc/mock_kvstore_service.h
+++ b/tensorstore/kvstore/tsgrpc/mock_kvstore_service.h
@@ -34,10 +34,10 @@ class MockKvStoreService : public kvstore::grpc_gen::KvStoreService::Service {
  public:
   using ServiceType = ::tensorstore_grpc::kvstore::grpc_gen::KvStoreService;
 
-  TENSORSTORE_GRPC_MOCK(Read, ::tensorstore_grpc::kvstore::ReadRequest,
-                        ::tensorstore_grpc::kvstore::ReadResponse);
-  TENSORSTORE_GRPC_MOCK(Write, ::tensorstore_grpc::kvstore::WriteRequest,
-                        ::tensorstore_grpc::kvstore::WriteResponse);
+  TENSORSTORE_GRPC_SERVER_STREAMING_MOCK(Read, ::tensorstore_grpc::kvstore::ReadRequest,
+                                         ::tensorstore_grpc::kvstore::ReadResponse);
+  TENSORSTORE_GRPC_CLIENT_STREAMING_MOCK(Write, ::tensorstore_grpc::kvstore::WriteRequest,
+                                         ::tensorstore_grpc::kvstore::WriteResponse);
   TENSORSTORE_GRPC_MOCK(Delete, ::tensorstore_grpc::kvstore::DeleteRequest,
                         ::tensorstore_grpc::kvstore::DeleteResponse);
   TENSORSTORE_GRPC_SERVER_STREAMING_MOCK(


### PR DESCRIPTION
This commit changes tsgrpc protocol in backward-incompatible manner, addressing issue #137.
After this change, it becomes possible to read and write values that exceed the theoretic maximum
of 2 GiB per proto message.
