### PR TITLE
Remove tsgrpc_kvstore address log

### DIFF
--- a/tensorstore/kvstore/tsgrpc/tsgrpc.cc
+++ b/tensorstore/kvstore/tsgrpc/tsgrpc.cc
@@ -467,7 +467,6 @@ Future<kvstore::DriverPtr> TsGrpcKeyValueStoreSpec::DoOpen() const {
   // TODO: Determine a better mapping to a grpc credentials for this.
   // grpc::Credentials ties the authentication to the communication channel
   // See: <grpcpp/security/credentials.h>, https://grpc.io/docs/guides/auth/
-  ABSL_LOG(INFO) << "tsgrpc_kvstore address=" << data_.address;
 
   driver->channel_ =
       grpc::CreateChannel(data_.address, data_.credentials->GetCredentials());


### PR DESCRIPTION
Hi!

We are working on integrating tensorstore with [YTsaurus](https://github.com/ytsaurus/ytsaurus) as an underlying storage.

We were able to do some PoC and received some feedback from our customers already:
`tsgrpc_kvstore address=` log seems not very useful and makes a lot of noise in some cases

We believe that most users would prefer not to have this log line

Cheers,
Aleksandr.
