### PR TITLE
Update `pypi-publish` to latest release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
           path: dist
           merge-multiple: true
       - name: Publish to PyPI (main server)
-        uses: pypa/gh-action-pypi-publish@54b39fb9371c0b3a6f9f14bb8a67394defc7a806 # 2020-09-25
+        uses: pypa/gh-action-pypi-publish@v1.9.0
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
Stopped using commit hash in favor of tag release at https://github.com/marketplace/actions/pypi-publish