### PR TITLE
Add TIFF Key-Value Store Implementation (take 2)

### DIFF
--- a/tensorstore/kvstore/tiff/BUILD
+++ b/tensorstore/kvstore/tiff/BUILD
@@ -52,6 +52,7 @@ tensorstore_cc_library(
         ":tiff_details",
         "//tensorstore/internal/cache:async_cache",
         "//tensorstore/internal/cache:cache",
+        "//tensorstore/internal/cache_key",
         "//tensorstore/internal/estimate_heap_usage",
         "//tensorstore/kvstore",
         "//tensorstore/kvstore:byte_range",
@@ -61,6 +62,8 @@ tensorstore_cc_library(
         "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/strings:cord",
         "@com_google_riegeli//riegeli/bytes:cord_reader",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/hash",
     ],
 )
 

--- a/tensorstore/kvstore/tiff/BUILD
+++ b/tensorstore/kvstore/tiff/BUILD
@@ -36,6 +36,7 @@ tensorstore_cc_test(
     srcs = ["tiff_key_value_store_test.cc"],
     deps = [
         ":tiff_key_value_store",
+        ":tiff_test_util",
         "//tensorstore/kvstore",
         "//tensorstore/kvstore:test_util",
         "//tensorstore/kvstore/memory",
@@ -72,6 +73,7 @@ tensorstore_cc_test(
     srcs = ["tiff_dir_cache_test.cc"],
     deps = [
         ":tiff_dir_cache",
+        ":tiff_test_util",
         "//tensorstore:context",
         "//tensorstore/internal/cache",
         "//tensorstore/internal/cache:cache_pool_resource",
@@ -114,4 +116,10 @@ tensorstore_cc_test(
         "@com_google_riegeli//riegeli/bytes:cord_reader",
         "@com_google_riegeli//riegeli/bytes:string_reader",
     ],
+)
+
+tensorstore_cc_library(
+    name = "tiff_test_util",
+    srcs = ["tiff_test_util.cc"],
+    hdrs = ["tiff_test_util.h"],
 )

--- a/tensorstore/kvstore/tiff/BUILD
+++ b/tensorstore/kvstore/tiff/BUILD
@@ -13,6 +13,8 @@ tensorstore_cc_library(
         "tiff_key_value_store.h",
     ],
     deps = [
+        ":tiff_details",
+        ":tiff_dir_cache",
         "//tensorstore/kvstore",
         "//tensorstore/util:future",
         "//tensorstore/internal:data_copy_concurrency_resource",

--- a/tensorstore/kvstore/tiff/BUILD
+++ b/tensorstore/kvstore/tiff/BUILD
@@ -43,3 +43,40 @@ tensorstore_cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+tensorstore_cc_library(
+    name = "tiff_dir_cache",
+    srcs = ["tiff_dir_cache.cc"],
+    hdrs = ["tiff_dir_cache.h"],
+    deps = [
+        "//tensorstore/internal/cache:async_cache",
+        "//tensorstore/internal/cache:cache",
+        "//tensorstore/internal/estimate_heap_usage",
+        "//tensorstore/kvstore",
+        "//tensorstore/kvstore:byte_range",
+        "//tensorstore/util:executor",
+        "//tensorstore/util:future",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/log:absl_log",
+        "@com_google_absl//absl/strings:cord",
+    ],
+)
+
+tensorstore_cc_test(
+    name = "tiff_dir_cache_test",
+    srcs = ["tiff_dir_cache_test.cc"],
+    deps = [
+        ":tiff_dir_cache",
+        "//tensorstore:context",
+        "//tensorstore/internal/cache",
+        "//tensorstore/internal/cache:cache_pool_resource",
+        "//tensorstore/kvstore",
+        "//tensorstore/kvstore/memory",
+        "//tensorstore/kvstore:test_util",
+        "//tensorstore/util:executor",
+        "//tensorstore/util:status_testutil",
+        "@com_google_absl//absl/strings:cord",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/tensorstore/kvstore/tiff/BUILD
+++ b/tensorstore/kvstore/tiff/BUILD
@@ -1,0 +1,45 @@
+load("//bazel:tensorstore.bzl", "tensorstore_cc_library", "tensorstore_cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+tensorstore_cc_library(
+    name = "tiff_key_value_store",
+    srcs = [
+        "tiff_key_value_store.cc",
+        "tiff_parser.cc",
+    ],
+    hdrs = [
+        "tiff_key_value_store.h",
+        "tiff_parser.h",
+    ],
+    deps = [
+        "//tensorstore/kvstore",
+        "//tensorstore/util:future",
+        "//tensorstore/internal:data_copy_concurrency_resource",
+        "//tensorstore/internal:intrusive_ptr",
+        "//tensorstore/internal/cache",
+        "//tensorstore/internal/cache:async_cache",
+        "//tensorstore/internal/cache:cache_pool_resource",
+        "@com_google_absl//absl/log:absl_log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_riegeli//riegeli/bytes:cord_reader",
+        "@com_google_absl//absl/functional:function_ref",
+    ],
+)
+
+tensorstore_cc_test(
+    name = "tiff_key_value_store_test",
+    srcs = ["tiff_key_value_store_test.cc"],
+    deps = [
+        ":tiff_key_value_store",
+        "//tensorstore/kvstore",
+        "//tensorstore/kvstore:test_util",
+        "//tensorstore/kvstore/memory",
+        "//tensorstore/util:future",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/tensorstore/kvstore/tiff/BUILD
+++ b/tensorstore/kvstore/tiff/BUILD
@@ -8,11 +8,9 @@ tensorstore_cc_library(
     name = "tiff_key_value_store",
     srcs = [
         "tiff_key_value_store.cc",
-        "tiff_parser.cc",
     ],
     hdrs = [
         "tiff_key_value_store.h",
-        "tiff_parser.h",
     ],
     deps = [
         "//tensorstore/kvstore",
@@ -49,6 +47,7 @@ tensorstore_cc_library(
     srcs = ["tiff_dir_cache.cc"],
     hdrs = ["tiff_dir_cache.h"],
     deps = [
+        ":tiff_details",
         "//tensorstore/internal/cache:async_cache",
         "//tensorstore/internal/cache:cache",
         "//tensorstore/internal/estimate_heap_usage",
@@ -59,6 +58,7 @@ tensorstore_cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/strings:cord",
+        "@com_google_riegeli//riegeli/bytes:cord_reader",
     ],
 )
 

--- a/tensorstore/kvstore/tiff/BUILD
+++ b/tensorstore/kvstore/tiff/BUILD
@@ -80,3 +80,33 @@ tensorstore_cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+tensorstore_cc_library(
+    name = "tiff_details",
+    srcs = ["tiff_details.cc"],
+    hdrs = ["tiff_details.h"],
+    deps = [
+        "//tensorstore/internal/log:verbose_flag",
+        "//tensorstore/util:status",
+        "//tensorstore/util:str_cat",
+        "@com_google_absl//absl/log:absl_log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_riegeli//riegeli/bytes:reader",
+        "@com_google_riegeli//riegeli/endian:endian_reading",
+    ],
+)
+
+tensorstore_cc_test(
+    name = "tiff_details_test",
+    size = "small",
+    srcs = ["tiff_details_test.cc"],
+    deps = [
+        ":tiff_details",
+        "//tensorstore/util:status_testutil",
+        "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest_main",
+        "@com_google_riegeli//riegeli/bytes:cord_reader",
+        "@com_google_riegeli//riegeli/bytes:string_reader",
+    ],
+)

--- a/tensorstore/kvstore/tiff/index.rst
+++ b/tensorstore/kvstore/tiff/index.rst
@@ -1,0 +1,55 @@
+.. _tiff-kvstore-driver:
+
+``tiff`` Key-Value Store driver
+======================================================
+
+The ``tiff`` driver implements support for reading from 
+`TIFF <https://en.wikipedia.org/wiki/TIFF>`_ format
+files on top of a base key-value store. It provides access to individual tiles or strips
+within TIFF images in a standardized key-value format.
+
+.. json:schema:: kvstore/tiff
+
+Example JSON specifications
+---------------------------
+
+.. code-block:: json
+
+    { 
+      "driver": "tiff",
+      "base": "gs://my-bucket/path/to/file.tiff" 
+    }
+
+.. code-block:: json
+   
+    { 
+      "driver": "tiff",
+      "base": { 
+        "driver": "file", 
+        "path": "/path/to/image.tiff" 
+      } 
+    }
+
+
+Key Format
+----------
+
+Keys are formatted as: ``tile/<ifd>/<row>/<col>``
+
+* ``<ifd>``: The Image File Directory (IFD) index (0-based).
+* ``<row>``: Row index for the tile/strip (0-based)
+* ``<col>``: Column index for the tile (always 0 for stripped TIFFs)
+
+For example, the key ``tile/0/3/2`` refers to the tile at row 3, column 2 in the first IFD.
+
+Features
+--------
+
+* Support for both tiled and stripped TIFF formats
+* Multi-page TIFF support via IFD indices
+* Handles various bit depths and sample formats
+
+Limitations
+-----------
+
+* Writing is not supported (read-only) and not all TIFF features are supported.

--- a/tensorstore/kvstore/tiff/schema.yml
+++ b/tensorstore/kvstore/tiff/schema.yml
@@ -1,0 +1,33 @@
+$schema: http://json-schema.org/draft-07/schema#
+$id: kvstore/tiff
+title: Read-only adapter for accessing tiles/strips within TIFF images.
+description: JSON specification of the TIFF key-value store.
+allOf:
+- $ref: KvStore
+- type: object
+  properties:
+    driver:
+      const: tiff
+    base:
+      $ref: KvStore
+      title: Underlying key-value store with path to a TIFF file.
+      description: |-
+        Key-value store that provides access to the TIFF file.
+        Each key in this store corresponds to a TIFF file.
+    cache_pool:
+      $ref: ContextResource
+      description: |-
+        Specifies or references a previously defined `Context.cache_pool`.  It
+        is typically more convenient to specify a default `~Context.cache_pool`
+        in the `.context`.
+      default: cache_pool
+    data_copy_concurrency:
+      $ref: ContextResource
+      description: |-
+        Specifies or references a previously defined
+        `Context.data_copy_concurrency`.  It is typically more
+        convenient to specify a default `~Context.data_copy_concurrency` in
+        the `.context`.
+      default: data_copy_concurrency
+  required:
+  - base

--- a/tensorstore/kvstore/tiff/tiff_details.cc
+++ b/tensorstore/kvstore/tiff/tiff_details.cc
@@ -1,0 +1,204 @@
+// Copyright 2023 The TensorStore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tensorstore/kvstore/tiff/tiff_details.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cassert>
+#include <limits>
+
+#include "absl/log/absl_log.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "riegeli/bytes/reader.h"
+#include "riegeli/endian/endian_reading.h"
+#include "tensorstore/internal/log/verbose_flag.h"
+#include "tensorstore/util/str_cat.h"
+
+namespace tensorstore {
+namespace internal_tiff_kvstore {
+namespace {
+
+using ::riegeli::ReadBigEndian16;
+using ::riegeli::ReadBigEndian32;
+using ::riegeli::ReadBigEndian64;
+using ::riegeli::ReadLittleEndian16;
+using ::riegeli::ReadLittleEndian32;
+using ::riegeli::ReadLittleEndian64;
+
+ABSL_CONST_INIT internal_log::VerboseFlag tiff_logging("tiff_details");
+
+// Helper function to read a value based on endianness
+template <typename T>
+bool ReadEndian(riegeli::Reader& reader, Endian endian, T& value) {
+  if (endian == Endian::kLittle) {
+    if constexpr (sizeof(T) == 2) return ReadLittleEndian16(reader, value);
+    if constexpr (sizeof(T) == 4) return ReadLittleEndian32(reader, value);
+    if constexpr (sizeof(T) == 8) return ReadLittleEndian64(reader, value);
+  } else {
+    if constexpr (sizeof(T) == 2) return ReadBigEndian16(reader, value);
+    if constexpr (sizeof(T) == 4) return ReadBigEndian32(reader, value);
+    if constexpr (sizeof(T) == 8) return ReadBigEndian64(reader, value);
+  }
+  return false;
+}
+
+}  // namespace
+
+absl::Status ParseTiffHeader(
+    riegeli::Reader& reader,
+    Endian& endian,
+    uint64_t& first_ifd_offset) {
+  
+  // Pull first 8 bytes which contain the header info
+  if (!reader.Pull(8)) {
+    return absl::InvalidArgumentError(
+        "Failed to read TIFF header: insufficient data");
+  }
+
+  // Read byte order mark (II or MM)
+  char byte_order[2];
+  if (!reader.Read(2, byte_order)) {
+    return absl::InvalidArgumentError(
+        "Failed to read TIFF header byte order mark");
+  }
+
+  if (byte_order[0] == 'I' && byte_order[1] == 'I') {
+    endian = Endian::kLittle;
+  } else if (byte_order[0] == 'M' && byte_order[1] == 'M') {
+    endian = Endian::kBig;
+  } else {
+    return absl::InvalidArgumentError(
+        "Invalid TIFF byte order mark");
+  }
+
+  // Read magic number (42 for standard TIFF)
+  uint16_t magic;
+  if (!ReadEndian(reader, endian, magic) || magic != 42) {
+    return absl::InvalidArgumentError(
+        "Invalid TIFF magic number");
+  }
+
+  // Read offset to first IFD
+  uint32_t offset32;
+  if (!ReadEndian(reader, endian, offset32)) {
+    return absl::InvalidArgumentError(
+        "Failed to read first IFD offset");
+  }
+  first_ifd_offset = offset32;
+
+  ABSL_LOG_IF(INFO, tiff_logging)
+      << "TIFF header: endian=" << (endian == Endian::kLittle ? "little" : "big")
+      << " first_ifd_offset=" << first_ifd_offset;
+
+  return absl::OkStatus();
+}
+
+absl::Status ParseTiffDirectory(
+    riegeli::Reader& reader,
+    Endian endian,
+    uint64_t directory_offset,
+    size_t available_size,
+    TiffDirectory& out) {
+  
+  // Position reader at directory offset
+  if (!reader.Seek(directory_offset)) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Failed to seek to IFD at offset %d", directory_offset));
+  }
+
+  // Read number of directory entries (2 bytes)
+  if (available_size < 2) {
+    return absl::DataLossError("Insufficient data to read IFD entry count");
+  }
+
+  uint16_t num_entries;
+  if (!ReadEndian(reader, endian, num_entries)) {
+    return absl::InvalidArgumentError("Failed to read IFD entry count");
+  }
+
+  // Each entry is 12 bytes, plus 2 bytes for count and 4 bytes for next IFD offset
+  size_t required_size = 2 + (num_entries * 12) + 4;
+  if (available_size < required_size) {
+    return absl::DataLossError(absl::StrFormat(
+        "Insufficient data to read complete IFD: need %d bytes, have %d",
+        required_size, available_size));
+  }
+
+  // Initialize directory fields
+  out.endian = endian;
+  out.directory_offset = directory_offset;
+  out.entries.clear();
+  out.entries.reserve(num_entries);
+
+  // Read each entry
+  for (uint16_t i = 0; i < num_entries; ++i) {
+    IfdEntry entry;
+    
+    // Read tag
+    if (!ReadEndian(reader, endian, entry.tag)) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Failed to read tag for IFD entry %d", i));
+    }
+
+    // Read type
+    uint16_t type_raw;
+    if (!ReadEndian(reader, endian, type_raw)) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Failed to read type for IFD entry %d", i));
+    }
+    entry.type = static_cast<TiffDataType>(type_raw);
+
+    // Read count
+    uint32_t count32;
+    if (!ReadEndian(reader, endian, count32)) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Failed to read count for IFD entry %d", i));
+    }
+    entry.count = count32;
+
+    // Read value/offset
+    uint32_t value32;
+    if (!ReadEndian(reader, endian, value32)) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("Failed to read value/offset for IFD entry %d", i));
+    }
+    entry.value_or_offset = value32;
+
+    ABSL_LOG_IF(INFO, tiff_logging)
+        << absl::StrFormat("IFD entry %d: tag=0x%x type=%d count=%d value=%d",
+                          i, entry.tag, static_cast<int>(entry.type),
+                          entry.count, entry.value_or_offset);
+
+    out.entries.push_back(entry);
+  }
+
+  // Read offset to next IFD
+  uint32_t next_ifd;
+  if (!ReadEndian(reader, endian, next_ifd)) {
+    return absl::InvalidArgumentError("Failed to read next IFD offset");
+  }
+  out.next_ifd_offset = next_ifd;
+
+  ABSL_LOG_IF(INFO, tiff_logging)
+      << "Read IFD with " << num_entries << " entries"
+      << ", next_ifd_offset=" << out.next_ifd_offset;
+
+  return absl::OkStatus();
+}
+
+}  // namespace internal_tiff_kvstore
+}  // namespace tensorstore

--- a/tensorstore/kvstore/tiff/tiff_details.cc
+++ b/tensorstore/kvstore/tiff/tiff_details.cc
@@ -1,4 +1,4 @@
-// Copyright 2023 The TensorStore Authors
+// Copyright 2025 The TensorStore Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 #include "riegeli/bytes/reader.h"
 #include "riegeli/endian/endian_reading.h"
 #include "tensorstore/internal/log/verbose_flag.h"
-#include "tensorstore/util/status.h"  // for TENSORSTORE_RETURN_IF_ERROR
+#include "tensorstore/util/status.h"
 #include "tensorstore/util/str_cat.h"
 
 namespace tensorstore {

--- a/tensorstore/kvstore/tiff/tiff_details.h
+++ b/tensorstore/kvstore/tiff/tiff_details.h
@@ -75,6 +75,9 @@ struct IfdEntry {
   uint64_t count;
   uint64_t value_or_offset;  // For values that fit in 4/8 bytes, this is the value
                             // Otherwise, this is an offset to the data
+  
+  // Flag to indicate if this entry references an external array
+  bool is_external_array = false;
 };
 
 // Represents a TIFF Image File Directory (IFD)
@@ -118,6 +121,21 @@ absl::Status ParseTiffDirectory(
 absl::Status ParseImageDirectory(
     const std::vector<IfdEntry>& entries,
     ImageDirectory& out);
+
+// Parse an external array from a reader
+absl::Status ParseExternalArray(
+    riegeli::Reader& reader,
+    Endian endian,
+    uint64_t offset,
+    uint64_t count,
+    TiffDataType data_type,
+    std::vector<uint64_t>& out);
+
+// Determine if an IFD entry represents an external array based on type and count
+bool IsExternalArray(TiffDataType type, uint64_t count);
+
+// Get the size in bytes for a given TIFF data type
+size_t GetTiffDataTypeSize(TiffDataType type);
 
 }  // namespace internal_tiff_kvstore
 }  // namespace tensorstore

--- a/tensorstore/kvstore/tiff/tiff_details.h
+++ b/tensorstore/kvstore/tiff/tiff_details.h
@@ -34,88 +34,88 @@ enum class Endian {
 };
 
 enum Tag : uint16_t {
-  kImageWidth        = 256,
-  kImageLength       = 257,
-  kBitsPerSample     = 258,
-  kCompression       = 259,
-  kPhotometric       = 262,
-  kSamplesPerPixel   = 277,
-  kRowsPerStrip      = 278,
-  kStripOffsets      = 273,
-  kStripByteCounts   = 279,
-  kPlanarConfig      = 284,
-  kTileWidth         = 322,
-  kTileLength        = 323,
-  kTileOffsets       = 324,
-  kTileByteCounts    = 325,
-  kSampleFormat      = 339,
+  kImageWidth = 256,
+  kImageLength = 257,
+  kBitsPerSample = 258,
+  kCompression = 259,
+  kPhotometric = 262,
+  kSamplesPerPixel = 277,
+  kRowsPerStrip = 278,
+  kStripOffsets = 273,
+  kStripByteCounts = 279,
+  kPlanarConfig = 284,
+  kTileWidth = 322,
+  kTileLength = 323,
+  kTileOffsets = 324,
+  kTileByteCounts = 325,
+  kSampleFormat = 339,
 };
 
 // Common compression types
 enum class CompressionType : uint16_t {
-  kNone       = 1,
+  kNone = 1,
   kCCITTGroup3 = 2,
   kCCITTGroup4 = 3,
-  kLZW        = 5,
-  kJPEG       = 6,
-  kDeflate    = 8,
-  kPackBits   = 32773,
+  kLZW = 5,
+  kJPEG = 6,
+  kDeflate = 8,
+  kPackBits = 32773,
 };
 
 // Photometric interpretations
 enum class PhotometricType : uint16_t {
   kWhiteIsZero = 0,
   kBlackIsZero = 1,
-  kRGB        = 2,
-  kPalette    = 3,
+  kRGB = 2,
+  kPalette = 3,
   kTransparencyMask = 4,
-  kCMYK       = 5,
-  kYCbCr      = 6,
-  kCIELab     = 8,
+  kCMYK = 5,
+  kYCbCr = 6,
+  kCIELab = 8,
 };
 
 // Planar configurations
 enum class PlanarConfigType : uint16_t {
-  kChunky     = 1,  // RGBRGBRGB...
-  kPlanar     = 2,  // RRR...GGG...BBB...
+  kChunky = 1,  // RGBRGBRGB...
+  kPlanar = 2,  // RRR...GGG...BBB...
 };
 
 // Sample formats
 enum class SampleFormatType : uint16_t {
-  kUnsignedInteger  = 1,
-  kSignedInteger    = 2,
-  kIEEEFloat        = 3,
-  kUndefined        = 4,
+  kUnsignedInteger = 1,
+  kSignedInteger = 2,
+  kIEEEFloat = 3,
+  kUndefined = 4,
 };
 
 // TIFF data types
 enum class TiffDataType : uint16_t {
-  kByte = 1,      // 8-bit unsigned integer
-  kAscii = 2,     // 8-bit bytes with last byte null
-  kShort = 3,     // 16-bit unsigned integer
-  kLong = 4,      // 32-bit unsigned integer
-  kRational = 5,  // Two 32-bit unsigned integers
-  kSbyte = 6,     // 8-bit signed integer
-  kUndefined = 7, // 8-bit byte
-  kSshort = 8,    // 16-bit signed integer
-  kSlong = 9,     // 32-bit signed integer
-  kSrational = 10,// Two 32-bit signed integers
-  kFloat = 11,    // 32-bit IEEE floating point
-  kDouble = 12,   // 64-bit IEEE floating point
-  kIfd = 13,      // 32-bit unsigned integer (offset)
-  kLong8 = 16,    // BigTIFF 64-bit unsigned integer
-  kSlong8 = 17,   // BigTIFF 64-bit signed integer
-  kIfd8 = 18,     // BigTIFF 64-bit unsigned integer (offset)
+  kByte = 1,        // 8-bit unsigned integer
+  kAscii = 2,       // 8-bit bytes with last byte null
+  kShort = 3,       // 16-bit unsigned integer
+  kLong = 4,        // 32-bit unsigned integer
+  kRational = 5,    // Two 32-bit unsigned integers
+  kSbyte = 6,       // 8-bit signed integer
+  kUndefined = 7,   // 8-bit byte
+  kSshort = 8,      // 16-bit signed integer
+  kSlong = 9,       // 32-bit signed integer
+  kSrational = 10,  // Two 32-bit signed integers
+  kFloat = 11,      // 32-bit IEEE floating point
+  kDouble = 12,     // 64-bit IEEE floating point
+  kIfd = 13,        // 32-bit unsigned integer (offset)
+  kLong8 = 16,      // BigTIFF 64-bit unsigned integer
+  kSlong8 = 17,     // BigTIFF 64-bit signed integer
+  kIfd8 = 18,       // BigTIFF 64-bit unsigned integer (offset)
 };
 
 // IFD entry in a TIFF file
 struct IfdEntry {
-  Tag      tag;
+  Tag tag;
   TiffDataType type;
   uint64_t count;
-  uint64_t value_or_offset;  // For values that fit in 4/8 bytes, this is the value
-                            // Otherwise, this is an offset to the data
-  
+  uint64_t value_or_offset;  // For values that fit in 4/8 bytes, this is the
+                             // value Otherwise, this is an offset to the data
+
   // Flag to indicate if this entry references an external array
   bool is_external_array = false;
 };
@@ -138,9 +138,11 @@ struct ImageDirectory {
   uint32_t tile_height = 0;
   uint32_t rows_per_strip = 0;
   uint16_t samples_per_pixel = 1;  // Default to 1 sample per pixel
-  uint16_t compression = static_cast<uint16_t>(CompressionType::kNone);  // Default to uncompressed
+  uint16_t compression =
+      static_cast<uint16_t>(CompressionType::kNone);  // Default to uncompressed
   uint16_t photometric = 0;
-  uint16_t planar_config = static_cast<uint16_t>(PlanarConfigType::kChunky);  // Default to chunky
+  uint16_t planar_config =
+      static_cast<uint16_t>(PlanarConfigType::kChunky);  // Default to chunky
   std::vector<uint16_t> bits_per_sample;  // Bits per sample for each channel
   std::vector<uint16_t> sample_format;    // Format type for each channel
   std::vector<uint64_t> strip_offsets;
@@ -150,42 +152,31 @@ struct ImageDirectory {
 };
 
 // Parse the TIFF header at the current position
-absl::Status ParseTiffHeader(
-    riegeli::Reader& reader,
-    Endian& endian,
-    uint64_t& first_ifd_offset);
+absl::Status ParseTiffHeader(riegeli::Reader& reader, Endian& endian,
+                             uint64_t& first_ifd_offset);
 
 // Parse a TIFF directory at the given offset
-absl::Status ParseTiffDirectory(
-    riegeli::Reader& reader,
-    Endian endian,
-    uint64_t directory_offset,
-    size_t available_size,
-    TiffDirectory& out);
+absl::Status ParseTiffDirectory(riegeli::Reader& reader, Endian endian,
+                                uint64_t directory_offset,
+                                size_t available_size, TiffDirectory& out);
 
 // Parse IFD entries into an ImageDirectory structure
-absl::Status ParseImageDirectory(
-    const std::vector<IfdEntry>& entries,
-    ImageDirectory& out);
+absl::Status ParseImageDirectory(const std::vector<IfdEntry>& entries,
+                                 ImageDirectory& out);
 
 // Parse an external array from a reader
-absl::Status ParseExternalArray(
-    riegeli::Reader& reader,
-    Endian endian,
-    uint64_t offset,
-    uint64_t count,
-    TiffDataType data_type,
-    std::vector<uint64_t>& out);
+absl::Status ParseExternalArray(riegeli::Reader& reader, Endian endian,
+                                uint64_t offset, uint64_t count,
+                                TiffDataType data_type,
+                                std::vector<uint64_t>& out);
 
 // Parse a uint16_t array from an IFD entry
-absl::Status ParseUint16Array(
-    riegeli::Reader& reader,
-    Endian endian,
-    uint64_t offset,
-    uint64_t count,
-    std::vector<uint16_t>& out);
+absl::Status ParseUint16Array(riegeli::Reader& reader, Endian endian,
+                              uint64_t offset, uint64_t count,
+                              std::vector<uint16_t>& out);
 
-// Determine if an IFD entry represents an external array based on type and count
+// Determine if an IFD entry represents an external array based on type and
+// count
 bool IsExternalArray(TiffDataType type, uint64_t count);
 
 // Get the size in bytes for a given TIFF data type

--- a/tensorstore/kvstore/tiff/tiff_details.h
+++ b/tensorstore/kvstore/tiff/tiff_details.h
@@ -1,0 +1,93 @@
+// Copyright 2023 The TensorStore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENSORSTORE_KVSTORE_TIFF_TIFF_DETAILS_H_
+#define TENSORSTORE_KVSTORE_TIFF_TIFF_DETAILS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "riegeli/bytes/reader.h"
+
+namespace tensorstore {
+namespace internal_tiff_kvstore {
+
+enum class Endian {
+  kLittle,
+  kBig,
+};
+
+// TIFF data types
+enum class TiffDataType : uint16_t {
+  kByte = 1,      // 8-bit unsigned integer
+  kAscii = 2,     // 8-bit bytes with last byte null
+  kShort = 3,     // 16-bit unsigned integer
+  kLong = 4,      // 32-bit unsigned integer
+  kRational = 5,  // Two 32-bit unsigned integers
+  kSbyte = 6,     // 8-bit signed integer
+  kUndefined = 7, // 8-bit byte
+  kSshort = 8,    // 16-bit signed integer
+  kSlong = 9,     // 32-bit signed integer
+  kSrational = 10,// Two 32-bit signed integers
+  kFloat = 11,    // 32-bit IEEE floating point
+  kDouble = 12,   // 64-bit IEEE floating point
+  kIfd = 13,      // 32-bit unsigned integer (offset)
+  kLong8 = 16,    // BigTIFF 64-bit unsigned integer
+  kSlong8 = 17,   // BigTIFF 64-bit signed integer
+  kIfd8 = 18,     // BigTIFF 64-bit unsigned integer (offset)
+};
+
+// IFD entry in a TIFF file
+struct IfdEntry {
+  uint16_t tag;
+  TiffDataType type;
+  uint64_t count;
+  uint64_t value_or_offset;  // For values that fit in 4/8 bytes, this is the value
+                            // Otherwise, this is an offset to the data
+};
+
+// Represents a TIFF Image File Directory (IFD)
+struct TiffDirectory {
+  // Basic header info
+  Endian endian;
+  uint64_t directory_offset;  // Offset to this IFD from start of file
+  uint64_t next_ifd_offset;   // Offset to next IFD (0 if none)
+
+  // Entries in this IFD
+  std::vector<IfdEntry> entries;
+};
+
+// Parse the TIFF header at the current position
+absl::Status ParseTiffHeader(
+    riegeli::Reader& reader,
+    Endian& endian,
+    uint64_t& first_ifd_offset);
+
+// Parse a TIFF directory at the given offset
+absl::Status ParseTiffDirectory(
+    riegeli::Reader& reader,
+    Endian endian,
+    uint64_t directory_offset,
+    size_t available_size,
+    TiffDirectory& out);
+
+}  // namespace internal_tiff_kvstore
+}  // namespace tensorstore
+
+#endif  // TENSORSTORE_KVSTORE_TIFF_TIFF_DETAILS_H_

--- a/tensorstore/kvstore/tiff/tiff_details.h
+++ b/tensorstore/kvstore/tiff/tiff_details.h
@@ -33,6 +33,21 @@ enum class Endian {
   kBig,
 };
 
+enum Tag : uint16_t {
+  kImageWidth        = 256,
+  kImageLength       = 257,
+  kBitsPerSample     = 258,
+  kCompression       = 259,
+  kPhotometric       = 262,
+  kStripOffsets      = 273,
+  kRowsPerStrip      = 278,
+  kStripByteCounts   = 279,
+  kTileWidth         = 322,
+  kTileLength        = 323,
+  kTileOffsets       = 324,
+  kTileByteCounts    = 325,
+};
+
 // TIFF data types
 enum class TiffDataType : uint16_t {
   kByte = 1,      // 8-bit unsigned integer
@@ -55,7 +70,7 @@ enum class TiffDataType : uint16_t {
 
 // IFD entry in a TIFF file
 struct IfdEntry {
-  uint16_t tag;
+  Tag      tag;
   TiffDataType type;
   uint64_t count;
   uint64_t value_or_offset;  // For values that fit in 4/8 bytes, this is the value
@@ -73,6 +88,18 @@ struct TiffDirectory {
   std::vector<IfdEntry> entries;
 };
 
+struct ImageDirectory {
+  uint32_t width = 0;
+  uint32_t height = 0;
+  uint32_t tile_width = 0;
+  uint32_t tile_height = 0;
+  uint32_t rows_per_strip = 0;
+  std::vector<uint64_t> strip_offsets;
+  std::vector<uint64_t> strip_bytecounts;
+  std::vector<uint64_t> tile_offsets;
+  std::vector<uint64_t> tile_bytecounts;
+};
+
 // Parse the TIFF header at the current position
 absl::Status ParseTiffHeader(
     riegeli::Reader& reader,
@@ -86,6 +113,11 @@ absl::Status ParseTiffDirectory(
     uint64_t directory_offset,
     size_t available_size,
     TiffDirectory& out);
+
+// Parse IFD entries into an ImageDirectory structure
+absl::Status ParseImageDirectory(
+    const std::vector<IfdEntry>& entries,
+    ImageDirectory& out);
 
 }  // namespace internal_tiff_kvstore
 }  // namespace tensorstore

--- a/tensorstore/kvstore/tiff/tiff_details.h
+++ b/tensorstore/kvstore/tiff/tiff_details.h
@@ -1,4 +1,4 @@
-// Copyright 2023 The TensorStore Authors
+// Copyright 2025 The TensorStore Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tensorstore/kvstore/tiff/tiff_details.h
+++ b/tensorstore/kvstore/tiff/tiff_details.h
@@ -118,6 +118,10 @@ struct IfdEntry {
 
   // Flag to indicate if this entry references an external array
   bool is_external_array = false;
+
+  constexpr static auto ApplyMembers = [](auto&& x, auto f) {
+    return f(x.tag, x.type, x.count, x.value_or_offset, x.is_external_array);
+  };
 };
 
 // Represents a TIFF Image File Directory (IFD)
@@ -129,6 +133,10 @@ struct TiffDirectory {
 
   // Entries in this IFD
   std::vector<IfdEntry> entries;
+
+  constexpr static auto ApplyMembers = [](auto&& x, auto f) {
+    return f(x.endian, x.directory_offset, x.next_ifd_offset, x.entries);
+  };
 };
 
 struct ImageDirectory {
@@ -149,6 +157,13 @@ struct ImageDirectory {
   std::vector<uint64_t> strip_bytecounts;
   std::vector<uint64_t> tile_offsets;
   std::vector<uint64_t> tile_bytecounts;
+
+  constexpr static auto ApplyMembers = [](auto&& x, auto f) {
+    return f(x.width, x.height, x.tile_width, x.tile_height, x.rows_per_strip,
+             x.samples_per_pixel, x.compression, x.photometric, x.planar_config,
+             x.bits_per_sample, x.sample_format, x.strip_offsets,
+             x.strip_bytecounts, x.tile_offsets, x.tile_bytecounts);
+  };
 };
 
 // Parse the TIFF header at the current position

--- a/tensorstore/kvstore/tiff/tiff_details_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_details_test.cc
@@ -1,0 +1,138 @@
+// Copyright 2023 The TensorStore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tensorstore/kvstore/tiff/tiff_details.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/status/status.h"
+#include "riegeli/bytes/cord_reader.h"
+#include "riegeli/bytes/string_reader.h"
+#include "tensorstore/util/status_testutil.h"
+
+namespace {
+
+using ::tensorstore::internal_tiff_kvstore::Endian;
+using ::tensorstore::internal_tiff_kvstore::IfdEntry;
+using ::tensorstore::internal_tiff_kvstore::ParseTiffDirectory;
+using ::tensorstore::internal_tiff_kvstore::ParseTiffHeader;
+using ::tensorstore::internal_tiff_kvstore::TiffDataType;
+using ::tensorstore::internal_tiff_kvstore::TiffDirectory;
+
+TEST(TiffDetailsTest, ParseValidTiffHeader) {
+  // Create a minimal valid TIFF header (II, 42, offset 8)
+  static constexpr unsigned char kHeader[] = {
+      'I', 'I',             // Little endian
+      42, 0,               // Magic number (little endian)
+      8, 0, 0, 0,         // Offset to first IFD (little endian)
+  };
+
+  riegeli::StringReader reader(
+      std::string_view(reinterpret_cast<const char*>(kHeader), sizeof(kHeader)));
+
+  Endian endian;
+  uint64_t first_ifd_offset;
+  ASSERT_THAT(ParseTiffHeader(reader, endian, first_ifd_offset),
+              ::tensorstore::IsOk());
+  EXPECT_EQ(endian, Endian::kLittle);
+  EXPECT_EQ(first_ifd_offset, 8);
+}
+
+TEST(TiffDetailsTest, ParseBadByteOrder) {
+  // Create an invalid TIFF header with wrong byte order marker
+  static constexpr unsigned char kHeader[] = {
+      'X', 'X',             // Invalid byte order
+      42, 0,               // Magic number
+      8, 0, 0, 0,         // Offset to first IFD
+  };
+
+  riegeli::StringReader reader(
+      std::string_view(reinterpret_cast<const char*>(kHeader), sizeof(kHeader)));
+
+  Endian endian;
+  uint64_t first_ifd_offset;
+  EXPECT_THAT(ParseTiffHeader(reader, endian, first_ifd_offset),
+              ::tensorstore::MatchesStatus(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(TiffDetailsTest, ParseBadMagic) {
+  // Create an invalid TIFF header with wrong magic number
+  static constexpr unsigned char kHeader[] = {
+      'I', 'I',             // Little endian
+      43, 0,               // Wrong magic number
+      8, 0, 0, 0,         // Offset to first IFD
+  };
+
+  riegeli::StringReader reader(
+      std::string_view(reinterpret_cast<const char*>(kHeader), sizeof(kHeader)));
+
+  Endian endian;
+  uint64_t first_ifd_offset;
+  EXPECT_THAT(ParseTiffHeader(reader, endian, first_ifd_offset),
+              ::tensorstore::MatchesStatus(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(TiffDetailsTest, ParseValidDirectory) {
+  // Create a minimal valid IFD with one entry
+  static constexpr unsigned char kIfd[] = {
+      1, 0,                // Number of entries
+      1, 0,                // Tag (ImageWidth)
+      3, 0,                // Type (SHORT)
+      1, 0, 0, 0,         // Count
+      100, 0, 0, 0,       // Value (100)
+      0, 0, 0, 0,         // Next IFD offset (0 = no more)
+  };
+
+  riegeli::StringReader reader(
+      std::string_view(reinterpret_cast<const char*>(kIfd), sizeof(kIfd)));
+
+  TiffDirectory dir;
+  ASSERT_THAT(ParseTiffDirectory(reader, Endian::kLittle, 0, sizeof(kIfd), dir),
+              ::tensorstore::IsOk());
+  
+  EXPECT_EQ(dir.entries.size(), 1);
+  EXPECT_EQ(dir.next_ifd_offset, 0);
+  
+  const auto& entry = dir.entries[0];
+  EXPECT_EQ(entry.tag, 1);
+  EXPECT_EQ(entry.type, TiffDataType::kShort);
+  EXPECT_EQ(entry.count, 1);
+  EXPECT_EQ(entry.value_or_offset, 100);
+}
+
+TEST(TiffDetailsTest, ParseTruncatedDirectory) {
+  // Create a truncated IFD
+  static constexpr unsigned char kTruncatedIfd[] = {
+      1, 0,                // Number of entries
+      1, 0,                // Tag (partial entry)
+  };
+
+  riegeli::StringReader reader(
+      std::string_view(reinterpret_cast<const char*>(kTruncatedIfd),
+                      sizeof(kTruncatedIfd)));
+
+  TiffDirectory dir;
+  EXPECT_THAT(
+      ParseTiffDirectory(reader, Endian::kLittle, 0, sizeof(kTruncatedIfd), dir),
+      ::tensorstore::MatchesStatus(absl::StatusCode::kDataLoss));
+}
+
+}  // namespace

--- a/tensorstore/kvstore/tiff/tiff_details_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_details_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2023 The TensorStore Authors
+// Copyright 2025 The TensorStore Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tensorstore/kvstore/tiff/tiff_dir_cache.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache.cc
@@ -64,7 +64,6 @@ struct ReadDirectoryOp
         << "StartTiffRead " << entry_->key()
         << " with byte range: " << options_.byte_range;
 
-    // 1.  Default to the "slice‑first" strategy -----------------------------
     is_full_read_ = false;
     file_offset_ = 0;  // We’re reading from the start.
     parse_result_ = std::make_shared<TiffParseResult>();

--- a/tensorstore/kvstore/tiff/tiff_dir_cache.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache.cc
@@ -18,6 +18,8 @@
 
 #include "absl/base/attributes.h"
 #include "absl/log/absl_log.h"
+#include "absl/status/status.h"
+#include "riegeli/bytes/cord_reader.h"
 #include "tensorstore/internal/cache/async_cache.h"
 #include "tensorstore/internal/estimate_heap_usage/estimate_heap_usage.h"
 #include "tensorstore/internal/log/verbose_flag.h"
@@ -25,9 +27,6 @@
 #include "tensorstore/kvstore/operations.h"
 #include "tensorstore/kvstore/read_result.h"
 #include "tensorstore/util/future.h"
-#include "absl/status/status.h"
-#include "riegeli/bytes/cord_reader.h"
-
 
 namespace tensorstore {
 namespace internal_tiff_kvstore {
@@ -36,28 +35,34 @@ namespace {
 
 ABSL_CONST_INIT internal_log::VerboseFlag tiff_logging("tiff");
 
-struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> {
+struct ReadDirectoryOp
+    : public internal::AtomicReferenceCount<ReadDirectoryOp> {
   TiffDirectoryCache::Entry* entry_;
   std::shared_ptr<const TiffParseResult> existing_read_data_;
   kvstore::ReadOptions options_;
-  
-  // True if we have switched to reading the entire file or recognized that no partial reads are needed.
+
+  // True if we have switched to reading the entire file or recognized that no
+  // partial reads are needed.
   bool is_full_read_;
 
-  // The resulting parse data we will build up. This includes raw file data, IFD entries, etc.
+  // The resulting parse data we will build up. This includes raw file data, IFD
+  // entries, etc.
   std::shared_ptr<TiffParseResult> parse_result_;
 
   // The offset in the file that corresponds to parse_result_->raw_data[0].
-  // If file_offset_ is 1000, then parse_result_->raw_data’s index 0 is byte 1000 in the TIFF file.
+  // If file_offset_ is 1000, then parse_result_->raw_data’s index 0 is byte
+  // 1000 in the TIFF file.
   uint64_t file_offset_;
 
-  // The next IFD offset we expect to parse. If 0, we have no more IFDs in the chain.
+  // The next IFD offset we expect to parse. If 0, we have no more IFDs in the
+  // chain.
   uint64_t next_ifd_offset_;
 
   void StartTiffRead() {
     auto& cache = internal::GetOwningCache(*entry_);
-    ABSL_LOG(INFO)
-        << "StartTiffRead " << entry_->key() << " with byte range: " << options_.byte_range;
+    ABSL_LOG_IF(INFO, tiff_logging)
+        << "StartTiffRead " << entry_->key()
+        << " with byte range: " << options_.byte_range;
 
     // 1.  Default to the "slice‑first" strategy -----------------------------
     is_full_read_ = false;
@@ -74,55 +79,66 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
           OptionalByteRangeRequest::Range(0, kInitialReadBytes);
     }
 
-    auto future = cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
-    ABSL_LOG(INFO) << "Issued initial read request for key: " << entry_->key() << " with byte range: " << options_.byte_range;
+    auto future =
+        cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
+    ABSL_LOG_IF(INFO, tiff_logging)
+        << "Issued initial read request for key: " << entry_->key()
+        << " with byte range: " << options_.byte_range;
     future.Force();
     future.ExecuteWhenReady(
         [self = internal::IntrusivePtr<ReadDirectoryOp>(this)](
             ReadyFuture<kvstore::ReadResult> ready) {
-          ABSL_LOG(INFO) << "Initial read completed for key: " << self->entry_->key();
+          ABSL_LOG_IF(INFO, tiff_logging)
+              << "Initial read completed for key: " << self->entry_->key();
           self->OnHeaderReadComplete(std::move(ready));
         });
   }
 
-  // Called after the initial read completes (the read that tries to parse the TIFF header).
+  // Called after the initial read completes (the read that tries to parse the
+  // TIFF header).
   void OnHeaderReadComplete(ReadyFuture<kvstore::ReadResult> ready) {
     const auto& r = ready.result();
-    ABSL_LOG(INFO) << "OnHeaderReadComplete called for key: " << entry_->key();
+    ABSL_LOG_IF(INFO, tiff_logging)
+        << "OnHeaderReadComplete called for key: " << entry_->key();
 
     if (!r.ok()) {
-      ABSL_LOG(WARNING) << "Read failed with status: " << r.status();
+      ABSL_LOG_IF(WARNING, tiff_logging)
+          << "Read failed with status: " << r.status();
       // Possibly partial read overshot the file
       if (!is_full_read_ && absl::IsOutOfRange(r.status())) {
         is_full_read_ = true;
         // Switch to a full read
-        ABSL_LOG(INFO) << "Overshot file. Issuing a full read for key: " << entry_->key();
+        ABSL_LOG_IF(INFO, tiff_logging)
+            << "Overshot file. Issuing a full read for key: " << entry_->key();
         options_.byte_range = {};
         auto& cache = internal::GetOwningCache(*entry_);
-        auto retry_future = cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
+        auto retry_future =
+            cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
         retry_future.Force();
         retry_future.ExecuteWhenReady(
-            [self = internal::IntrusivePtr<ReadDirectoryOp>(this)]
-            (ReadyFuture<kvstore::ReadResult> f) {
+            [self = internal::IntrusivePtr<ReadDirectoryOp>(this)](
+                ReadyFuture<kvstore::ReadResult> f) {
               self->OnHeaderReadComplete(std::move(f));
             });
         return;
       }
       // Some other error
-      entry_->ReadError(internal::ConvertInvalidArgumentToFailedPrecondition(r.status()));
+      entry_->ReadError(
+          internal::ConvertInvalidArgumentToFailedPrecondition(r.status()));
       return;
     }
 
     if (r->not_found()) {
-      ABSL_LOG(WARNING) << "File not found for key: " << entry_->key();
+      ABSL_LOG_IF(WARNING, tiff_logging)
+          << "File not found for key: " << entry_->key();
       entry_->ReadError(absl::NotFoundError("File not found"));
       return;
     }
     if (r->aborted()) {
       if (existing_read_data_) {
         // Return existing data
-        entry_->ReadSuccess(TiffDirectoryCache::ReadState{
-            existing_read_data_, std::move(r->stamp)});
+        entry_->ReadSuccess(TiffDirectoryCache::ReadState{existing_read_data_,
+                                                          std::move(r->stamp)});
       } else {
         entry_->ReadError(absl::AbortedError("Read aborted."));
       }
@@ -131,7 +147,7 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
 
     // We now have partial data at offsets [0..someSize).
     parse_result_->raw_data = std::move(r->value);
-    uint64_t bytes_received = parse_result_->raw_data.size(); 
+    uint64_t bytes_received = parse_result_->raw_data.size();
 
     // If we got less data than requested, treat it as a full read.
     if (!is_full_read_ && bytes_received < kInitialReadBytes) {
@@ -143,22 +159,27 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
     // Parse the header
     riegeli::CordReader cord_reader(&parse_result_->raw_data);
     Endian endian;
-    absl::Status header_status = ParseTiffHeader(cord_reader, endian, next_ifd_offset_);
+    absl::Status header_status =
+        ParseTiffHeader(cord_reader, endian, next_ifd_offset_);
     if (!header_status.ok()) {
-      ABSL_LOG(WARNING) << "Failed to parse TIFF header: " << header_status;
+      ABSL_LOG_IF(WARNING, tiff_logging)
+          << "Failed to parse TIFF header: " << header_status;
       entry_->ReadError(header_status);
       return;
     }
-    ABSL_LOG(INFO) << "TIFF header parsed successfully."
-                                    << ", Next IFD offset: " << next_ifd_offset_;
+    ABSL_LOG_IF(INFO, tiff_logging)
+        << "TIFF header parsed successfully."
+        << ", Next IFD offset: " << next_ifd_offset_;
     parse_result_->endian = endian;
 
-    // Now parse the first IFD at next_ifd_offset_ if it’s nonzero. Then traverse the rest.
-    // Because we’re at file_offset_ = 0, next_ifd_offset_ is within the buffer if next_ifd_offset_ < bytes_received.
+    // Now parse the first IFD at next_ifd_offset_ if it’s nonzero. Then
+    // traverse the rest. Because we’re at file_offset_ = 0, next_ifd_offset_ is
+    // within the buffer if next_ifd_offset_ < bytes_received.
     StartParsingIFDs(std::move(r->stamp));
   }
 
-  /// This function begins (or continues) parsing IFDs at next_ifd_offset_ until we reach offset=0 or an error.
+  /// This function begins (or continues) parsing IFDs at next_ifd_offset_ until
+  /// we reach offset=0 or an error.
   void StartParsingIFDs(tensorstore::TimestampedStorageGeneration stamp) {
     if (next_ifd_offset_ == 0) {
       // No IFDs, so finalize
@@ -178,7 +199,8 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
       return;
     }
 
-    // If parse succeeded, check if the IFD we parsed gave us a new offset for the next IFD.
+    // If parse succeeded, check if the IFD we parsed gave us a new offset for
+    // the next IFD.
     if (next_ifd_offset_ == 0) {
       OnAllIFDsDone(std::move(stamp));
       return;
@@ -189,46 +211,54 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
     // until we either run out of data or IFDs.
     StartParsingIFDs(std::move(stamp));
   }
-  
-  // This attempts to parse one IFD at next_ifd_offset_ using our current buffer. 
-  // If that offset is beyond the buffer range, returns OutOfRangeError. If success, updates parse_result_, next_ifd_offset_.
+
+  // This attempts to parse one IFD at next_ifd_offset_ using our current
+  // buffer. If that offset is beyond the buffer range, returns OutOfRangeError.
+  // If success, updates parse_result_, next_ifd_offset_.
   absl::Status ParseOneIFD() {
-    ABSL_LOG(INFO) << "Parsing IFD at offset: " << next_ifd_offset_
-                                    << " for key: " << entry_->key();
-    // 1. We slice the buffer so that raw_data[0] corresponds to next_ifd_offset_ in the file if it’s inside the current buffer’s range.
+    ABSL_LOG_IF(INFO, tiff_logging)
+        << "Parsing IFD at offset: " << next_ifd_offset_
+        << " for key: " << entry_->key();
+    // 1. We slice the buffer so that raw_data[0] corresponds to
+    // next_ifd_offset_ in the file if it’s inside the current buffer’s range.
     //    The difference is next_ifd_offset_ - file_offset_.
     if (next_ifd_offset_ < file_offset_) {
-      return absl::DataLossError("IFD offset is behind our current buffer offset, which is unexpected.");
+      return absl::DataLossError(
+          "IFD offset is behind our current buffer offset, which is "
+          "unexpected.");
     }
 
     uint64_t relative_pos = next_ifd_offset_ - file_offset_;
     uint64_t buffer_size = parse_result_->raw_data.size();
 
     if (relative_pos > buffer_size) {
-      ABSL_LOG(WARNING) << "Buffer underflow while parsing IFD. Needed next_ifd_offset: "
-                                         << relative_pos << ", Max available offset: " << file_offset_ + buffer_size;
+      ABSL_LOG_IF(WARNING, tiff_logging)
+          << "Buffer underflow while parsing IFD. Needed next_ifd_offset: "
+          << relative_pos
+          << ", Max available offset: " << file_offset_ + buffer_size;
       // We’re missing data
-      return absl::OutOfRangeError("Next IFD is outside our current buffer range.");
+      return absl::OutOfRangeError(
+          "Next IFD is outside our current buffer range.");
     }
 
     // Slice off everything before relative_pos, because we no longer need it.
     // For absl::Cord, we can do subcord. Suppose subcord(offset, npos).
     // Then we update file_offset_ to next_ifd_offset_.
     // Example approach:
-    parse_result_->raw_data = parse_result_->raw_data.Subcord(relative_pos, buffer_size - relative_pos);
+    parse_result_->raw_data = parse_result_->raw_data.Subcord(
+        relative_pos, buffer_size - relative_pos);
     file_offset_ = next_ifd_offset_;
 
-    // Now parse from the beginning of parse_result_->raw_data as offset=0 in the local sense.
+    // Now parse from the beginning of parse_result_->raw_data as offset=0 in
+    // the local sense.
     riegeli::CordReader reader(&parse_result_->raw_data);
     TiffDirectory dir;
-    absl::Status s = ParseTiffDirectory(reader,
-                                        parse_result_->endian,
-                                        /*local_offset=*/0, 
-                                        parse_result_->raw_data.size(), 
-                                        dir);
+    absl::Status s = ParseTiffDirectory(reader, parse_result_->endian,
+                                        /*local_offset=*/0,
+                                        parse_result_->raw_data.size(), dir);
     if (!s.ok()) {
-      ABSL_LOG(WARNING) << "Failed to parse IFD: " << s;
-      return s; // Could be OutOfRange, parse error, etc.
+      ABSL_LOG_IF(WARNING, tiff_logging) << "Failed to parse IFD: " << s;
+      return s;  // Could be OutOfRange, parse error, etc.
     }
 
     // Store the IFD’s entries in parse_result_->ifd_entries (or directories).
@@ -236,19 +266,24 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
 
     // Update next_ifd_offset_ to the directory’s next offset
     next_ifd_offset_ = dir.next_ifd_offset;
-    ABSL_LOG(INFO) << "Parsed IFD successfully. Next IFD offset: " << dir.next_ifd_offset;
+    ABSL_LOG_IF(INFO, tiff_logging)
+        << "Parsed IFD successfully. Next IFD offset: " << dir.next_ifd_offset;
     return absl::OkStatus();
   }
 
-  /// If we discover we need more data to parse the next IFD, we read newer bytes from the file.
-  /// Suppose we read from [file_offset_ + buffer.size(), file_offset_ + buffer.size() + chunk).
+  /// If we discover we need more data to parse the next IFD, we read newer
+  /// bytes from the file. Suppose we read from [file_offset_ + buffer.size(),
+  /// file_offset_ + buffer.size() + chunk).
   void RequestMoreData(tensorstore::TimestampedStorageGeneration stamp) {
-    ABSL_LOG(INFO) << "Requesting more data for key: " << entry_->key()
-                                    << ". Current buffer size: " << parse_result_->raw_data.size()
-                                    << ", Full read: " << parse_result_->full_read;
+    ABSL_LOG_IF(INFO, tiff_logging)
+        << "Requesting more data for key: " << entry_->key()
+        << ". Current buffer size: " << parse_result_->raw_data.size()
+        << ", Full read: " << parse_result_->full_read;
     if (parse_result_->full_read) {
-      // We’re already in full read mode and still are outOfRange => truncated file or corrupted offset
-      entry_->ReadError(absl::DataLossError("Insufficient data after full read."));
+      // We’re already in full read mode and still are outOfRange => truncated
+      // file or corrupted offset
+      entry_->ReadError(
+          absl::DataLossError("Insufficient data after full read."));
       return;
     }
 
@@ -257,35 +292,41 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
       // Start from the next IFD offset if it's beyond what we already have:
       uint64_t read_begin = std::max(current_data_end, next_ifd_offset_);
       uint64_t read_end = read_begin + kInitialReadBytes;
-  
+
       // If that end is some large threshold, we might want to do a full read:
       if (read_end > (16 * 1024 * 1024)) {  // example threshold
         is_full_read_ = true;
         options_.byte_range = OptionalByteRangeRequest(file_offset_);
       } else {
-        options_.byte_range = OptionalByteRangeRequest::Range(read_begin, read_end);
+        options_.byte_range =
+            OptionalByteRangeRequest::Range(read_begin, read_end);
       }
     } else {
-      // We set parse_result_->full_read but apparently we didn’t get enough data. 
-      // That’s an error or truncated file.
-      entry_->ReadError(absl::DataLossError("Need more data after already in full‑read mode."));
+      // We set parse_result_->full_read but apparently we didn’t get enough
+      // data. That’s an error or truncated file.
+      entry_->ReadError(absl::DataLossError(
+          "Need more data after already in full‑read mode."));
       return;
     }
 
     auto& cache = internal::GetOwningCache(*entry_);
-    auto fut = cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
-    ABSL_LOG(INFO) << "Issued additional read request for key: " << entry_->key()
-                                    << " with byte range: " << options_.byte_range;
+    auto fut =
+        cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
+    ABSL_LOG_IF(INFO, tiff_logging)
+        << "Issued additional read request for key: " << entry_->key()
+        << " with byte range: " << options_.byte_range;
     fut.Force();
     fut.ExecuteWhenReady(
-        [self = internal::IntrusivePtr<ReadDirectoryOp>(this), s=std::move(stamp)]
-        (ReadyFuture<kvstore::ReadResult> ready) mutable {
-          ABSL_LOG(INFO) << "Additional read completed for key: " << self->entry_->key();
+        [self = internal::IntrusivePtr<ReadDirectoryOp>(this),
+         s = std::move(stamp)](ReadyFuture<kvstore::ReadResult> ready) mutable {
+          ABSL_LOG_IF(INFO, tiff_logging)
+              << "Additional read completed for key: " << self->entry_->key();
           self->OnAdditionalDataRead(std::move(ready), std::move(s));
         });
   }
 
-    /// Called once more data arrives. We append that data to parse_result_->raw_data and attempt parsing the IFD again.
+  /// Called once more data arrives. We append that data to
+  /// parse_result_->raw_data and attempt parsing the IFD again.
   void OnAdditionalDataRead(ReadyFuture<kvstore::ReadResult> ready,
                             tensorstore::TimestampedStorageGeneration stamp) {
     const auto& r = ready.result();
@@ -295,40 +336,47 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
         is_full_read_ = true;
         options_.byte_range = OptionalByteRangeRequest(file_offset_);
         auto& cache = internal::GetOwningCache(*entry_);
-        auto future = cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
+        auto future =
+            cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
         future.Force();
         future.ExecuteWhenReady(
-            [self = internal::IntrusivePtr<ReadDirectoryOp>(this), st=std::move(stamp)]
-            (ReadyFuture<kvstore::ReadResult> f) mutable {
+            [self = internal::IntrusivePtr<ReadDirectoryOp>(this),
+             st =
+                 std::move(stamp)](ReadyFuture<kvstore::ReadResult> f) mutable {
               self->OnAdditionalDataRead(std::move(f), std::move(st));
             });
         return;
       }
-      entry_->ReadError(internal::ConvertInvalidArgumentToFailedPrecondition(r.status()));
+      entry_->ReadError(
+          internal::ConvertInvalidArgumentToFailedPrecondition(r.status()));
       return;
     }
 
     auto& rr = *r;
     if (rr.not_found()) {
-      entry_->ReadError(absl::NotFoundError("Not found during incremental read."));
+      entry_->ReadError(
+          absl::NotFoundError("Not found during incremental read."));
       return;
     }
     if (rr.aborted()) {
       if (existing_read_data_) {
-        entry_->ReadSuccess(TiffDirectoryCache::ReadState{
-            existing_read_data_, std::move(rr.stamp)});
+        entry_->ReadSuccess(TiffDirectoryCache::ReadState{existing_read_data_,
+                                                          std::move(rr.stamp)});
         return;
       }
       entry_->ReadError(absl::AbortedError("Read aborted, no existing data."));
       return;
     }
 
-    // If we're reading from next_ifd_offset directly (which is far away from our buffer end),
-    // we should reset our buffer instead of appending.
-    if (options_.byte_range.inclusive_min >= file_offset_ + parse_result_->raw_data.size()) {
+    // If we're reading from next_ifd_offset directly (which is far away from
+    // our buffer end), we should reset our buffer instead of appending.
+    if (options_.byte_range.inclusive_min >=
+        file_offset_ + parse_result_->raw_data.size()) {
       // This is a non-contiguous read, so replace buffer instead of appending
       parse_result_->raw_data = std::move(rr.value);
-      file_offset_ = options_.byte_range.inclusive_min;  // Update file offset to match new data
+      file_offset_ =
+          options_.byte_range
+              .inclusive_min;  // Update file offset to match new data
     } else {
       // Append new data to parse_result_->raw_data (contiguous read)
       size_t old_size = parse_result_->raw_data.size();
@@ -336,21 +384,24 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
       size_t new_size = parse_result_->raw_data.size();
 
       // If we got less data than requested, treat it as a full read
-      if (!is_full_read_ && (new_size - old_size) < (options_.byte_range.size() - old_size)) {
+      if (!is_full_read_ &&
+          (new_size - old_size) < (options_.byte_range.size() - old_size)) {
         parse_result_->full_read = true;
       }
     }
-    
+
     parse_result_->full_read = parse_result_->full_read || is_full_read_;
 
     // We can now try parsing the same IFD offset again
     StartParsingIFDs(std::move(stamp));
   }
 
- /// Called when we exhaust next_ifd_offset_ (i.e., reached offset=0 in the chain). We parse the final directory or load external arrays, etc.
+  /// Called when we exhaust next_ifd_offset_ (i.e., reached offset=0 in the
+  /// chain). We parse the final directory or load external arrays, etc.
   void OnAllIFDsDone(tensorstore::TimestampedStorageGeneration stamp) {
-    ABSL_LOG(INFO) << "All IFDs parsed successfully for key: " << entry_->key()
-                                    << ". Total directories: " << parse_result_->directories.size();
+    ABSL_LOG_IF(INFO, tiff_logging)
+        << "All IFDs parsed successfully for key: " << entry_->key()
+        << ". Total directories: " << parse_result_->directories.size();
     // We now have parse_result_->directories for all IFDs.
     // Reserve space for a matching list of ImageDirectory objects.
     parse_result_->image_directories.clear();
@@ -362,10 +413,11 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
     // Also check entries for external arrays.
     for (size_t i = 0; i < parse_result_->directories.size(); ++i) {
       // Parse the IFD into parse_result_->image_directories[i].
-      ABSL_LOG(INFO) << "Parsing image metadata from IFD #" << i << " for key: " << entry_->key();
-      absl::Status s = ParseImageDirectory(
-          parse_result_->directories[i].entries,
-          parse_result_->image_directories[i]);
+      ABSL_LOG_IF(INFO, tiff_logging) << "Parsing image metadata from IFD #"
+                                      << i << " for key: " << entry_->key();
+      absl::Status s =
+          ParseImageDirectory(parse_result_->directories[i].entries,
+                              parse_result_->image_directories[i]);
       if (!s.ok()) {
         entry_->ReadError(s);
         return;
@@ -380,7 +432,8 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
     }
 
     if (!has_external_arrays) {
-      ABSL_LOG(INFO) << "No external arrays found for key: " << entry_->key();
+      ABSL_LOG_IF(INFO, tiff_logging)
+          << "No external arrays found for key: " << entry_->key();
       // We’re done
       entry_->ReadSuccess(TiffDirectoryCache::ReadState{
           std::move(parse_result_), std::move(stamp)});
@@ -391,7 +444,8 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
     auto future = entry_->LoadExternalArrays(parse_result_, stamp);
     future.Force();
     future.ExecuteWhenReady(
-        [self = internal::IntrusivePtr<ReadDirectoryOp>(this), stamp](ReadyFuture<void> load_done) {
+        [self = internal::IntrusivePtr<ReadDirectoryOp>(this),
+         stamp](ReadyFuture<void> load_done) {
           if (!load_done.result().ok()) {
             self->entry_->ReadError(load_done.result().status());
             return;
@@ -408,18 +462,21 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
 Future<void> TiffDirectoryCache::Entry::LoadExternalArrays(
     std::shared_ptr<TiffParseResult> parse_result,
     tensorstore::TimestampedStorageGeneration stamp) {
-  ABSL_LOG(INFO) << "Loading external arrays for key: " << this->key();
+  ABSL_LOG_IF(INFO, tiff_logging)
+      << "Loading external arrays for key: " << this->key();
   // Collect all external arrays that need to be loaded
   struct ExternalArrayInfo {
     Tag tag;
     TiffDataType type;
     uint64_t offset;
     uint64_t count;
-    // Instead of a single array, we also track which index in image_directories we belong to.
+    // Instead of a single array, we also track which index in image_directories
+    // we belong to.
     size_t image_index;
-    // We'll store into either tile_offsets, strip_offsets, etc. based on the tag.
+    // We'll store into either tile_offsets, strip_offsets, etc. based on the
+    // tag.
   };
-  
+
   std::vector<ExternalArrayInfo> external_arrays;
 
   // Collect external arrays from each directory (and store them by index).
@@ -430,10 +487,10 @@ Future<void> TiffDirectoryCache::Entry::LoadExternalArrays(
       if (!entry.is_external_array) continue;
 
       ExternalArrayInfo info;
-      info.tag    = entry.tag;
-      info.type   = entry.type;
+      info.tag = entry.tag;
+      info.type = entry.type;
       info.offset = entry.value_or_offset;
-      info.count  = entry.count;
+      info.count = entry.count;
       info.image_index = i;
       external_arrays.push_back(info);
     }
@@ -443,12 +500,13 @@ Future<void> TiffDirectoryCache::Entry::LoadExternalArrays(
   if (external_arrays.empty()) {
     return MakeReadyFuture<void>();
   }
-  
+
   // For concurrency, we make a Promise/Future pair to track all loads.
   auto [promise, future] = PromiseFuturePair<void>::Make();
   auto& cache = internal::GetOwningCache(*this);
 
-  // Track how many arrays remain. We build a small shared struct to handle completion.
+  // Track how many arrays remain. We build a small shared struct to handle
+  // completion.
   struct LoadState : public internal::AtomicReferenceCount<LoadState> {
     size_t remaining_count;
     absl::Status first_error;
@@ -472,13 +530,15 @@ Future<void> TiffDirectoryCache::Entry::LoadExternalArrays(
     }
   };
 
-  auto load_state = internal::MakeIntrusivePtr<LoadState>(external_arrays.size(), std::move(promise));
+  auto load_state = internal::MakeIntrusivePtr<LoadState>(
+      external_arrays.size(), std::move(promise));
 
   // Issue read operations for each external array in parallel.
   for (const auto& array_info : external_arrays) {
-    ABSL_LOG(INFO) << "Reading external array for tag: " << static_cast<int>(array_info.tag)
-                                    << ", Offset: " << array_info.offset
-                                    << ", Count: " << array_info.count;
+    ABSL_LOG_IF(INFO, tiff_logging)
+        << "Reading external array for tag: "
+        << static_cast<int>(array_info.tag) << ", Offset: " << array_info.offset
+        << ", Count: " << array_info.count;
     // Compute the byte range.
     size_t element_size = GetTiffDataTypeSize(array_info.type);
     uint64_t byte_count = array_info.count * element_size;
@@ -488,45 +548,49 @@ Future<void> TiffDirectoryCache::Entry::LoadExternalArrays(
     read_opts.byte_range = OptionalByteRangeRequest::Range(
         array_info.offset, array_info.offset + byte_count);
 
-    ABSL_LOG(INFO)
+    ABSL_LOG_IF(INFO, tiff_logging)
         << "Reading external array for tag " << static_cast<int>(array_info.tag)
         << " at offset " << array_info.offset << " size " << byte_count;
 
-    auto read_future = cache.kvstore_driver_->Read(std::string(this->key()), read_opts);
+    auto read_future =
+        cache.kvstore_driver_->Read(std::string(this->key()), read_opts);
     read_future.Force();
-    
+
     read_future.ExecuteWhenReady(
-        [ls = load_state, &parse_result, array_info, stamp](
-            ReadyFuture<kvstore::ReadResult> ready) mutable {
+        [ls = load_state, &parse_result, array_info,
+         stamp](ReadyFuture<kvstore::ReadResult> ready) mutable {
           auto& rr = ready.result();
           if (!rr.ok()) {
-            ls->CompleteOne(internal::ConvertInvalidArgumentToFailedPrecondition(rr.status()));
+            ls->CompleteOne(
+                internal::ConvertInvalidArgumentToFailedPrecondition(
+                    rr.status()));
             return;
           }
 
           if (rr->not_found() || rr->aborted()) {
-            ls->CompleteOne(absl::DataLossError("Missing or aborted external array read."));
+            ls->CompleteOne(
+                absl::DataLossError("Missing or aborted external array read."));
             return;
           }
 
           // We'll parse the data into the image directory's appropriate field.
           // Grab the corresponding ImageDirectory.
-          auto& img_dir = parse_result->image_directories[array_info.image_index];
+          auto& img_dir =
+              parse_result->image_directories[array_info.image_index];
 
           // Create a reader for the data
           riegeli::CordReader cord_reader(&rr->value);
-          
+
           // Determine how to parse the array based on the tag and type
           absl::Status parse_status;
-          
+
           // Handle uint16_t arrays differently than uint64_t arrays
-          if (array_info.type == TiffDataType::kShort && 
-              (array_info.tag == Tag::kBitsPerSample || 
+          if (array_info.type == TiffDataType::kShort &&
+              (array_info.tag == Tag::kBitsPerSample ||
                array_info.tag == Tag::kSampleFormat)) {
-            
             // Parse uint16_t arrays
             std::vector<uint16_t>* uint16_array = nullptr;
-            
+
             switch (array_info.tag) {
               case Tag::kBitsPerSample:
                 uint16_array = &img_dir.bits_per_sample;
@@ -537,14 +601,11 @@ Future<void> TiffDirectoryCache::Entry::LoadExternalArrays(
               default:
                 break;
             }
-            
+
             if (uint16_array) {
-              parse_status = ParseUint16Array(
-                  cord_reader,
-                  parse_result->endian, 
-                  /*offset=*/0,
-                  array_info.count,
-                  *uint16_array);
+              parse_status = ParseUint16Array(cord_reader, parse_result->endian,
+                                              /*offset=*/0, array_info.count,
+                                              *uint16_array);
             } else {
               parse_status = absl::OkStatus();  // Skip unhandled uint16_t array
             }
@@ -569,13 +630,10 @@ Future<void> TiffDirectoryCache::Entry::LoadExternalArrays(
             }
 
             if (output_array) {
-              parse_status = ParseExternalArray(
-                  cord_reader,
-                  parse_result->endian, 
-                  /*offset=*/0,
-                  array_info.count,
-                  array_info.type,
-                  *output_array);
+              parse_status =
+                  ParseExternalArray(cord_reader, parse_result->endian,
+                                     /*offset=*/0, array_info.count,
+                                     array_info.type, *output_array);
             } else {
               parse_status = absl::OkStatus();  // Skip unhandled tag
             }
@@ -600,7 +658,7 @@ void TiffDirectoryCache::Entry::DoRead(AsyncCacheReadRequest request) {
   {
     ReadLock<ReadData> lock(*this);
     state->existing_read_data_ = lock.shared_data();
-    state->options_.generation_conditions.if_not_equal = 
+    state->options_.generation_conditions.if_not_equal =
         lock.read_state().stamp.generation;
   }
 
@@ -611,9 +669,7 @@ TiffDirectoryCache::Entry* TiffDirectoryCache::DoAllocateEntry() {
   return new Entry;
 }
 
-size_t TiffDirectoryCache::DoGetSizeofEntry() {
-  return sizeof(Entry);
-}
+size_t TiffDirectoryCache::DoGetSizeofEntry() { return sizeof(Entry); }
 
 }  // namespace internal_tiff_kvstore
 }  // namespace tensorstore

--- a/tensorstore/kvstore/tiff/tiff_dir_cache.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache.cc
@@ -47,7 +47,7 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
     ABSL_LOG_IF(INFO, tiff_logging)
         << "StartRead " << entry_->key();
     
-    // 1.  Default to the “slice‑first” strategy -----------------------------
+    // 1.  Default to the "slice‑first" strategy -----------------------------
     is_full_read_ = false;
 
     // Honour any *caller‑supplied* range that is smaller than the slice.
@@ -110,19 +110,19 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
       return;
     }
 
-    TiffDirectoryParseResult result;
-    result.raw_data = std::move(read_result.value);
+    auto parse_result = std::make_shared<TiffDirectoryParseResult>();
+    parse_result->raw_data = std::move(read_result.value);
     // If we asked for a slice but got fewer than requested bytes,
     // we effectively have the whole file.
     if (!is_full_read_ &&
-          result.raw_data.size() < internal_tiff_kvstore::kInitialReadBytes) {
-        result.full_read = true;
+          parse_result->raw_data.size() < internal_tiff_kvstore::kInitialReadBytes) {
+        parse_result->full_read = true;
       } else {
-        result.full_read = is_full_read_;
+        parse_result->full_read = is_full_read_;
       }
 
     // Create a riegeli reader from the cord
-    riegeli::CordReader cord_reader(&result.raw_data);
+    riegeli::CordReader cord_reader(&parse_result->raw_data);
     
     // Parse TIFF header
     Endian endian;
@@ -133,34 +133,215 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
       return;
     }
     
+    // Store the endian in the parse result for use when reading external arrays
+    parse_result->endian = endian;
+    
     // Parse TIFF directory at the given offset
     TiffDirectory directory;
     status = ParseTiffDirectory(
         cord_reader, endian, first_ifd_offset, 
-        result.raw_data.size() - first_ifd_offset, directory);
+        parse_result->raw_data.size() - first_ifd_offset, directory);
     if (!status.ok()) {
       entry_->ReadError(status);
       return;
     }
     
     // Store the IFD entries
-    result.ifd_entries = std::move(directory.entries);
+    parse_result->ifd_entries = std::move(directory.entries);
     
     // Parse the ImageDirectory from the IFD entries
-    status = ParseImageDirectory(result.ifd_entries, result.image_directory);
+    status = ParseImageDirectory(parse_result->ifd_entries, parse_result->image_directory);
     if (!status.ok()) {
       entry_->ReadError(status);
       return;
     }
-  
-    entry_->ReadSuccess(TiffDirectoryCache::ReadState{
-        std::make_shared<TiffDirectoryParseResult>(std::move(result)),
-        std::move(read_result.stamp)
-    });
+    
+    // Check if we need to load external arrays
+    bool has_external_arrays = false;
+    for (const auto& entry : parse_result->ifd_entries) {
+      if (entry.is_external_array) {
+        has_external_arrays = true;
+        break;
+      }
+    }
+    
+    if (has_external_arrays) {
+      // Load external arrays before completing the cache read
+      auto future = entry_->LoadExternalArrays(parse_result, read_result.stamp);
+      future.Force();
+      
+      // Once the external arrays are loaded, complete the cache read
+      future.ExecuteWhenReady(
+          [self = internal::IntrusivePtr<ReadDirectoryOp>(this), 
+           parse_result, 
+           stamp = std::move(read_result.stamp)](ReadyFuture<void> future) mutable {
+            auto& r = future.result();
+            if (!r.ok()) {
+              // If external arrays couldn't be loaded, propagate the error
+              self->entry_->ReadError(r.status());
+              return;
+            }
+            
+            // External arrays loaded successfully
+            self->entry_->ReadSuccess(TiffDirectoryCache::ReadState{
+                std::move(parse_result),
+                std::move(stamp)
+            });
+          });
+    } else {
+      // No external arrays to load
+      entry_->ReadSuccess(TiffDirectoryCache::ReadState{
+          std::move(parse_result),
+          std::move(read_result.stamp)
+      });
+    }
   }
 };
 
 }  // namespace
+
+Future<void> TiffDirectoryCache::Entry::LoadExternalArrays(
+    std::shared_ptr<TiffDirectoryParseResult> parse_result,
+    tensorstore::TimestampedStorageGeneration stamp) {
+  
+  // Get references to the arrays that might need loading
+  auto& entries = parse_result->ifd_entries;
+  auto& img_dir = parse_result->image_directory;
+  
+  // Collect all external arrays that need to be loaded
+  struct ExternalArrayInfo {
+    Tag tag;
+    TiffDataType type;
+    uint64_t offset;
+    uint64_t count;
+    std::vector<uint64_t>* output_array;
+  };
+  
+  std::vector<ExternalArrayInfo> external_arrays;
+  
+  // Check for strip and tile arrays that need to be loaded
+  for (const auto& entry : entries) {
+    if (!entry.is_external_array) continue;
+    
+    switch (entry.tag) {
+      case Tag::kStripOffsets:
+        external_arrays.push_back({entry.tag, entry.type, entry.value_or_offset, 
+                                 entry.count, &img_dir.strip_offsets});
+        break;
+      case Tag::kStripByteCounts:
+        external_arrays.push_back({entry.tag, entry.type, entry.value_or_offset, 
+                                 entry.count, &img_dir.strip_bytecounts});
+        break;
+      case Tag::kTileOffsets:
+        external_arrays.push_back({entry.tag, entry.type, entry.value_or_offset, 
+                                 entry.count, &img_dir.tile_offsets});
+        break;
+      case Tag::kTileByteCounts:
+        external_arrays.push_back({entry.tag, entry.type, entry.value_or_offset, 
+                                 entry.count, &img_dir.tile_bytecounts});
+        break;
+      default:
+        // Other external arrays aren't needed for the image directory
+        break;
+    }
+  }
+  
+  // If no external arrays to load, return immediately
+  if (external_arrays.empty()) {
+    return MakeReadyFuture<void>();
+  }
+  
+  ABSL_LOG_IF(INFO, tiff_logging)
+    << "Loading " << external_arrays.size() << " external arrays";
+  
+  // Create a Promise/Future pair to track completion of all array loads
+  auto [promise, future] = PromiseFuturePair<void>::Make();
+  auto& cache = internal::GetOwningCache(*this);
+  
+  // Track the number of array loads that remain to be processed
+  struct LoadState : public internal::AtomicReferenceCount<LoadState> {
+    size_t remaining_count;
+    absl::Status status;
+    Promise<void> promise;
+    
+    explicit LoadState(size_t count, Promise<void> promise) 
+        : remaining_count(count), promise(std::move(promise)) {}
+    
+    void CompleteOne(absl::Status s) {
+      if (!s.ok() && status.ok()) {
+        status = s;  // Store the first error encountered
+      }
+      
+      if (--remaining_count == 0) {
+        // All operations complete, resolve the promise
+        if (status.ok()) {
+          promise.SetResult(absl::OkStatus());
+        } else {
+          promise.SetResult(status);
+        }
+      }
+    }
+  };
+  
+  auto load_state = internal::MakeIntrusivePtr<LoadState>(
+      external_arrays.size(), std::move(promise));
+  
+  // Load each external array
+  for (const auto& array_info : external_arrays) {
+    // Calculate the byte range needed for this array
+    size_t element_size = GetTiffDataTypeSize(array_info.type);
+    size_t byte_count = array_info.count * element_size;
+    
+    // Set up the read options
+    kvstore::ReadOptions options;
+    options.generation_conditions.if_equal = stamp.generation;
+    options.byte_range = OptionalByteRangeRequest::Range(
+        array_info.offset, array_info.offset + byte_count);
+    
+    ABSL_LOG_IF(INFO, tiff_logging)
+      << "Reading external array for tag " << static_cast<int>(array_info.tag)
+      << " at offset " << array_info.offset << " size " << byte_count;
+    
+    // Issue the read request and track the future
+    auto read_future = cache.kvstore_driver_->Read(std::string(this->key()), options);
+    read_future.Force();
+    
+    // Process the read result when ready
+    read_future.ExecuteWhenReady(
+        [state = load_state, array_info, endian = parse_result->endian](
+            ReadyFuture<kvstore::ReadResult> ready) {
+          auto& r = ready.result();
+          if (!r.ok()) {
+            state->CompleteOne(internal::ConvertInvalidArgumentToFailedPrecondition(r.status()));
+            return;
+          }
+          
+          auto& read_result = *r;
+          if (read_result.not_found() || read_result.aborted()) {
+            state->CompleteOne(absl::DataLossError(
+                "External array not found or read aborted"));
+            return;
+          }
+          
+          // Create a reader for the data
+          riegeli::CordReader cord_reader(&read_result.value);
+          ABSL_LOG_IF(INFO, tiff_logging)
+              << "Parsing external array for tag " << static_cast<int>(array_info.tag)
+              << " at offset " << array_info.offset << " size " << read_result.value.size();
+              
+          // Parse the external array
+          auto status = ParseExternalArray(
+              cord_reader, endian, 0, array_info.count, 
+              array_info.type, *array_info.output_array);
+              
+          // Complete this array load operation
+          state->CompleteOne(status);
+        });
+  }
+  
+  // Return the future that completes when all array loads are finished
+  return future;
+}
 
 size_t TiffDirectoryCache::Entry::ComputeReadDataSizeInBytes(
     const void* read_data) {

--- a/tensorstore/kvstore/tiff/tiff_dir_cache.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache.cc
@@ -38,17 +38,31 @@ ABSL_CONST_INIT internal_log::VerboseFlag tiff_logging("tiff");
 
 struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> {
   TiffDirectoryCache::Entry* entry_;
-  std::shared_ptr<const TiffDirectoryParseResult> existing_read_data_;
+  std::shared_ptr<const TiffParseResult> existing_read_data_;
   kvstore::ReadOptions options_;
+  
+  // True if we have switched to reading the entire file or recognized that no partial reads are needed.
   bool is_full_read_;
 
-  void StartRead() {
+  // The resulting parse data we will build up. This includes raw file data, IFD entries, etc.
+  std::shared_ptr<TiffParseResult> parse_result_;
+
+  // The offset in the file that corresponds to parse_result_->raw_data[0].
+  // If file_offset_ is 1000, then parse_result_->raw_data’s index 0 is byte 1000 in the TIFF file.
+  uint64_t file_offset_;
+
+  // The next IFD offset we expect to parse. If 0, we have no more IFDs in the chain.
+  uint64_t next_ifd_offset_;
+
+  void StartTiffRead() {
     auto& cache = internal::GetOwningCache(*entry_);
     ABSL_LOG_IF(INFO, tiff_logging)
-        << "StartRead " << entry_->key();
+        << "StartTiffRead " << entry_->key() << " with byte range: " << options_.byte_range;
     
     // 1.  Default to the "slice‑first" strategy -----------------------------
     is_full_read_ = false;
+    file_offset_ = 0;  // We’re reading from the start.
+    parse_result_ = std::make_shared<TiffParseResult>();
 
     // Honour any *caller‑supplied* range that is smaller than the slice.
     if (!options_.byte_range.IsFull() &&
@@ -61,285 +75,477 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
     }
 
     auto future = cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
+    ABSL_LOG_IF(INFO, tiff_logging) << "Issued initial read request for key: " << entry_->key();
     future.Force();
     future.ExecuteWhenReady(
         [self = internal::IntrusivePtr<ReadDirectoryOp>(this)](
             ReadyFuture<kvstore::ReadResult> ready) {
-          self->OnReadComplete(std::move(ready));
+          ABSL_LOG_IF(INFO, tiff_logging) << "Initial read completed for key: " << self->entry_->key();
+          self->OnHeaderReadComplete(std::move(ready));
         });
   }
 
-  void OnReadComplete(ReadyFuture<kvstore::ReadResult> ready) {
-    auto& r = ready.result();
+  // Called after the initial read completes (the read that tries to parse the TIFF header).
+  void OnHeaderReadComplete(ReadyFuture<kvstore::ReadResult> ready) {
+    const auto& r = ready.result();
+    ABSL_LOG_IF(INFO, tiff_logging) << "OnHeaderReadComplete called for key: " << entry_->key();
+
     if (!r.ok()) {
-      // If the ranged request overshot the file, retry with a full read.
+      ABSL_LOG_IF(WARNING, tiff_logging) << "Read failed with status: " << r.status();
+      // Possibly partial read overshot the file
       if (!is_full_read_ && absl::IsOutOfRange(r.status())) {
-      is_full_read_ = true;
-      options_.byte_range = {};  // Full read.
-      auto retry_future =
-          internal::GetOwningCache(*entry_).kvstore_driver_->Read(
-              std::string(entry_->key()), options_);
-      retry_future.Force();
-      retry_future.ExecuteWhenReady(
-          [self = internal::IntrusivePtr<ReadDirectoryOp>(this)](
-              ReadyFuture<kvstore::ReadResult> f) {
-              self->OnReadComplete(std::move(f));
-          });
+        is_full_read_ = true;
+        // Switch to a full read
+        options_.byte_range = {};
+        auto& cache = internal::GetOwningCache(*entry_);
+        auto retry_future = cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
+        retry_future.Force();
+        retry_future.ExecuteWhenReady(
+            [self = internal::IntrusivePtr<ReadDirectoryOp>(this)]
+            (ReadyFuture<kvstore::ReadResult> f) {
+              self->OnHeaderReadComplete(std::move(f));
+            });
+        return;
+      }
+      // Some other error
+      entry_->ReadError(internal::ConvertInvalidArgumentToFailedPrecondition(r.status()));
       return;
+    }
+
+    if (r->not_found()) {
+      ABSL_LOG_IF(WARNING, tiff_logging) << "File not found for key: " << entry_->key();
+      entry_->ReadError(absl::NotFoundError("File not found"));
+      return;
+    }
+    if (r->aborted()) {
+      if (existing_read_data_) {
+        // Return existing data
+        entry_->ReadSuccess(TiffDirectoryCache::ReadState{
+            existing_read_data_, std::move(r->stamp)});
+      } else {
+        entry_->ReadError(absl::AbortedError("Read aborted."));
+      }
+      return;
+    }
+
+    // We now have partial data at offsets [0..someSize).
+    parse_result_->raw_data = std::move(r->value);
+    uint64_t bytes_received = parse_result_->raw_data.size(); 
+
+    // If we got less data than requested, treat it as a full read.
+    if (!is_full_read_ && bytes_received < kInitialReadBytes) {
+      parse_result_->full_read = true;
+    } else {
+      parse_result_->full_read = is_full_read_;
+    }
+
+    // Parse the header
+    riegeli::CordReader cord_reader(&parse_result_->raw_data);
+    Endian endian;
+    absl::Status header_status = ParseTiffHeader(cord_reader, endian, next_ifd_offset_);
+    if (!header_status.ok()) {
+      ABSL_LOG_IF(WARNING, tiff_logging) << "Failed to parse TIFF header: " << header_status;
+      entry_->ReadError(header_status);
+      return;
+    }
+    ABSL_LOG_IF(INFO, tiff_logging) << "TIFF header parsed successfully."
+                                    << ", Next IFD offset: " << next_ifd_offset_;
+    parse_result_->endian = endian;
+
+    // Now parse the first IFD at next_ifd_offset_ if it’s nonzero. Then traverse the rest.
+    // Because we’re at file_offset_ = 0, next_ifd_offset_ is within the buffer if next_ifd_offset_ < bytes_received.
+    StartParsingIFDs(std::move(r->stamp));
+  }
+
+  /// This function begins (or continues) parsing IFDs at next_ifd_offset_ until we reach offset=0 or an error.
+  void StartParsingIFDs(tensorstore::TimestampedStorageGeneration stamp) {
+    if (next_ifd_offset_ == 0) {
+      // No IFDs, so finalize
+      OnAllIFDsDone(std::move(stamp));
+      return;
+    }
+
+    absl::Status s = ParseOneIFD();
+    if (absl::IsOutOfRange(s)) {
+      // Means we need more data
+      RequestMoreData(std::move(stamp));
+      return;
+    }
+    if (!s.ok()) {
+      // Some other error
+      entry_->ReadError(s);
+      return;
+    }
+
+    // If parse succeeded, check if the IFD we parsed gave us a new offset for the next IFD.
+    if (next_ifd_offset_ == 0) {
+      OnAllIFDsDone(std::move(stamp));
+      return;
+    }
+
+    // “Recursive” or iterative approach: parse the next IFD in the chain.
+    // We could do a loop here, but we’ll just call StartParsingIFDs again
+    // until we either run out of data or IFDs.
+    StartParsingIFDs(std::move(stamp));
+  }
+  
+  // This attempts to parse one IFD at next_ifd_offset_ using our current buffer. 
+  // If that offset is beyond the buffer range, returns OutOfRangeError. If success, updates parse_result_, next_ifd_offset_.
+  absl::Status ParseOneIFD() {
+    ABSL_LOG_IF(INFO, tiff_logging) << "Parsing IFD at offset: " << next_ifd_offset_
+                                    << " for key: " << entry_->key();
+    // 1. We slice the buffer so that raw_data[0] corresponds to next_ifd_offset_ in the file if it’s inside the current buffer’s range.
+    //    The difference is next_ifd_offset_ - file_offset_.
+    if (next_ifd_offset_ < file_offset_) {
+      return absl::DataLossError("IFD offset is behind our current buffer offset, which is unexpected.");
+    }
+
+    uint64_t relative_pos = next_ifd_offset_ - file_offset_;
+    uint64_t buffer_size = parse_result_->raw_data.size();
+
+    if (relative_pos > buffer_size) {
+      ABSL_LOG_IF(WARNING, tiff_logging) << "Buffer underflow while parsing IFD. Needed offset: "
+                                         << relative_pos << ", Buffer size: " << buffer_size;
+      // We’re missing data
+      return absl::OutOfRangeError("Next IFD is outside our current buffer range.");
+    }
+
+    // Slice off everything before relative_pos, because we no longer need it.
+    // For absl::Cord, we can do subcord. Suppose subcord(offset, npos).
+    // Then we update file_offset_ to next_ifd_offset_.
+    // Example approach:
+    parse_result_->raw_data = parse_result_->raw_data.Subcord(relative_pos, buffer_size - relative_pos);
+    file_offset_ = next_ifd_offset_;
+
+    // Now parse from the beginning of parse_result_->raw_data as offset=0 in the local sense.
+    riegeli::CordReader reader(&parse_result_->raw_data);
+    TiffDirectory dir;
+    absl::Status s = ParseTiffDirectory(reader,
+                                        parse_result_->endian,
+                                        /*local_offset=*/0, 
+                                        parse_result_->raw_data.size(), 
+                                        dir);
+    if (!s.ok()) {
+      ABSL_LOG_IF(WARNING, tiff_logging) << "Failed to parse IFD: " << s;
+      return s; // Could be OutOfRange, parse error, etc.
+    }
+
+    // Store the IFD’s entries in parse_result_->ifd_entries (or directories).
+    parse_result_->directories.push_back(dir);
+
+    // Update next_ifd_offset_ to the directory’s next offset
+    next_ifd_offset_ = dir.next_ifd_offset;
+    ABSL_LOG_IF(INFO, tiff_logging) << "Parsed IFD successfully. Next IFD offset: " << dir.next_ifd_offset;
+    return absl::OkStatus();
+  }
+
+  /// If we discover we need more data to parse the next IFD, we read newer bytes from the file.
+  /// Suppose we read from [file_offset_ + buffer.size(), file_offset_ + buffer.size() + chunk).
+  void RequestMoreData(tensorstore::TimestampedStorageGeneration stamp) {
+    ABSL_LOG_IF(INFO, tiff_logging) << "Requesting more data for key: " << entry_->key()
+                                    << ". Current buffer size: " << parse_result_->raw_data.size()
+                                    << ", Full read: " << parse_result_->full_read;
+    if (parse_result_->full_read) {
+      // We’re already in full read mode and still are outOfRange => truncated file or corrupted offset
+      entry_->ReadError(absl::DataLossError("Insufficient data after full read."));
+      return;
+    }
+
+    if (!is_full_read_) {
+      // Expand by doubling or jump to the next IFD offset. 
+      // For simplicity, let’s do “extend the buffer by kInitialReadBytes again.”
+      size_t new_chunk_size = parse_result_->raw_data.size() + kInitialReadBytes;
+      // But the actual file offset we want is from [file_offset_ + parse_result_->raw_data.size()]
+      uint64_t read_begin = file_offset_ + parse_result_->raw_data.size();
+      uint64_t read_end = read_begin + new_chunk_size;
+
+      // If that end is some large threshold, we might want to do a full read:
+      if (read_end > (16 * 1024 * 1024)) {  // example threshold
+        is_full_read_ = true;
+        options_.byte_range = OptionalByteRangeRequest(file_offset_);
+      } else {
+        options_.byte_range = OptionalByteRangeRequest::Range(read_begin, read_end);
+      }
+    } else {
+      // We set parse_result_->full_read but apparently we didn’t get enough data. 
+      // That’s an error or truncated file.
+      entry_->ReadError(absl::DataLossError("Need more data after already in full‑read mode."));
+      return;
+    }
+
+    auto& cache = internal::GetOwningCache(*entry_);
+    auto fut = cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
+    ABSL_LOG_IF(INFO, tiff_logging) << "Issued additional read request for key: " << entry_->key()
+                                    << " with byte range: " << options_.byte_range;
+    fut.Force();
+    fut.ExecuteWhenReady(
+        [self = internal::IntrusivePtr<ReadDirectoryOp>(this), s=std::move(stamp)]
+        (ReadyFuture<kvstore::ReadResult> ready) mutable {
+          ABSL_LOG_IF(INFO, tiff_logging) << "Additional read completed for key: " << self->entry_->key();
+          self->OnAdditionalDataRead(std::move(ready), std::move(s));
+        });
+  }
+
+    /// Called once more data arrives. We append that data to parse_result_->raw_data and attempt parsing the IFD again.
+  void OnAdditionalDataRead(ReadyFuture<kvstore::ReadResult> ready,
+                            tensorstore::TimestampedStorageGeneration stamp) {
+    const auto& r = ready.result();
+    if (!r.ok()) {
+      // Possibly partial read overshoot again
+      if (!is_full_read_ && absl::IsOutOfRange(r.status())) {
+        is_full_read_ = true;
+        options_.byte_range = OptionalByteRangeRequest(file_offset_);
+        auto& cache = internal::GetOwningCache(*entry_);
+        auto future = cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
+        future.Force();
+        future.ExecuteWhenReady(
+            [self = internal::IntrusivePtr<ReadDirectoryOp>(this), st=std::move(stamp)]
+            (ReadyFuture<kvstore::ReadResult> f) mutable {
+              self->OnAdditionalDataRead(std::move(f), std::move(st));
+            });
+        return;
       }
       entry_->ReadError(internal::ConvertInvalidArgumentToFailedPrecondition(r.status()));
       return;
     }
 
-    auto& read_result = *r;
-    if (read_result.not_found()) {
-      entry_->ReadError(absl::NotFoundError(""));
+    auto& rr = *r;
+    if (rr.not_found()) {
+      entry_->ReadError(absl::NotFoundError("Not found during incremental read."));
       return;
     }
-
-    if (read_result.aborted()) {
-      // Return existing data if we have it
+    if (rr.aborted()) {
       if (existing_read_data_) {
         entry_->ReadSuccess(TiffDirectoryCache::ReadState{
-            existing_read_data_,
-            std::move(read_result.stamp)
-        });
+            existing_read_data_, std::move(rr.stamp)});
         return;
       }
-      entry_->ReadError(absl::AbortedError("Read aborted"));
+      entry_->ReadError(absl::AbortedError("Read aborted, no existing data."));
       return;
     }
 
-    auto parse_result = std::make_shared<TiffDirectoryParseResult>();
-    parse_result->raw_data = std::move(read_result.value);
-    // If we asked for a slice but got fewer than requested bytes,
-    // we effectively have the whole file.
-    if (!is_full_read_ &&
-          parse_result->raw_data.size() < internal_tiff_kvstore::kInitialReadBytes) {
-        parse_result->full_read = true;
-      } else {
-        parse_result->full_read = is_full_read_;
-      }
+    // Append new data to parse_result_->raw_data
+    size_t old_size = parse_result_->raw_data.size();
+    parse_result_->raw_data.Append(rr.value);
+    size_t new_size = parse_result_->raw_data.size();
 
-    // Create a riegeli reader from the cord
-    riegeli::CordReader cord_reader(&parse_result->raw_data);
-    
-    // Parse TIFF header
-    Endian endian;
-    uint64_t first_ifd_offset;
-    auto status = ParseTiffHeader(cord_reader, endian, first_ifd_offset);
-    if (!status.ok()) {
-      entry_->ReadError(status);
-      return;
-    }
-    
-    // Store the endian in the parse result for use when reading external arrays
-    parse_result->endian = endian;
-    
-    // Parse TIFF directory at the given offset
-    TiffDirectory directory;
-    status = ParseTiffDirectory(
-        cord_reader, endian, first_ifd_offset, 
-        parse_result->raw_data.size() - first_ifd_offset, directory);
-    if (!status.ok()) {
-      entry_->ReadError(status);
-      return;
-    }
-    
-    // Store the IFD entries
-    parse_result->ifd_entries = std::move(directory.entries);
-    
-    // Parse the ImageDirectory from the IFD entries
-    status = ParseImageDirectory(parse_result->ifd_entries, parse_result->image_directory);
-    if (!status.ok()) {
-      entry_->ReadError(status);
-      return;
-    }
-    
-    // Check if we need to load external arrays
-    bool has_external_arrays = false;
-    for (const auto& entry : parse_result->ifd_entries) {
-      if (entry.is_external_array) {
-        has_external_arrays = true;
-        break;
-      }
-    }
-    
-    if (has_external_arrays) {
-      // Load external arrays before completing the cache read
-      auto future = entry_->LoadExternalArrays(parse_result, read_result.stamp);
-      future.Force();
-      
-      // Once the external arrays are loaded, complete the cache read
-      future.ExecuteWhenReady(
-          [self = internal::IntrusivePtr<ReadDirectoryOp>(this), 
-           parse_result, 
-           stamp = std::move(read_result.stamp)](ReadyFuture<void> future) mutable {
-            auto& r = future.result();
-            if (!r.ok()) {
-              // If external arrays couldn't be loaded, propagate the error
-              self->entry_->ReadError(r.status());
-              return;
-            }
-            
-            // External arrays loaded successfully
-            self->entry_->ReadSuccess(TiffDirectoryCache::ReadState{
-                std::move(parse_result),
-                std::move(stamp)
-            });
-          });
+    // If we got less data than requested, treat it as a full read
+    if (!is_full_read_ && (new_size - old_size) < (options_.byte_range.size() - old_size)) {
+      parse_result_->full_read = true;
     } else {
-      // No external arrays to load
-      entry_->ReadSuccess(TiffDirectoryCache::ReadState{
-          std::move(parse_result),
-          std::move(read_result.stamp)
-      });
+      parse_result_->full_read = is_full_read_;
     }
+
+    // We can now try parsing the same IFD offset again
+    StartParsingIFDs(std::move(stamp));
+  }
+
+ /// Called when we exhaust next_ifd_offset_ (i.e., reached offset=0 in the chain). We parse the final directory or load external arrays, etc.
+  void OnAllIFDsDone(tensorstore::TimestampedStorageGeneration stamp) {
+    ABSL_LOG_IF(INFO, tiff_logging) << "All IFDs parsed successfully for key: " << entry_->key()
+                                    << ". Total directories: " << parse_result_->directories.size();
+    // We now have parse_result_->directories for all IFDs.
+    // Reserve space for a matching list of ImageDirectory objects.
+    parse_result_->image_directories.clear();
+    parse_result_->image_directories.resize(parse_result_->directories.size());
+
+    bool has_external_arrays = false;
+
+    // Parse each TiffDirectory into a corresponding ImageDirectory.
+    // Also check entries for external arrays.
+    for (size_t i = 0; i < parse_result_->directories.size(); ++i) {
+      // Parse the IFD into parse_result_->image_directories[i].
+      absl::Status s = ParseImageDirectory(
+          parse_result_->directories[i].entries,
+          parse_result_->image_directories[i]);
+      if (!s.ok()) {
+        entry_->ReadError(s);
+        return;
+      }
+
+      // Check for external arrays in this directory’s entries
+      for (const auto& e : parse_result_->directories[i].entries) {
+        if (e.is_external_array) {
+          has_external_arrays = true;
+        }
+      }
+    }
+
+    if (!has_external_arrays) {
+      ABSL_LOG_IF(INFO, tiff_logging) << "No external arrays found for key: " << entry_->key();
+      // We’re done
+      entry_->ReadSuccess(TiffDirectoryCache::ReadState{
+          std::move(parse_result_), std::move(stamp)});
+      return;
+    }
+
+    // Otherwise, load external arrays
+    auto future = entry_->LoadExternalArrays(parse_result_, stamp);
+    future.Force();
+    future.ExecuteWhenReady(
+        [self = internal::IntrusivePtr<ReadDirectoryOp>(this)](ReadyFuture<void> load_done) {
+          if (!load_done.result().ok()) {
+            self->entry_->ReadError(load_done.result().status());
+            return;
+          }
+          // Done
+          self->entry_->ReadSuccess(TiffDirectoryCache::ReadState{
+              std::move(self->parse_result_), {}});
+        });
   }
 };
 
 }  // namespace
 
 Future<void> TiffDirectoryCache::Entry::LoadExternalArrays(
-    std::shared_ptr<TiffDirectoryParseResult> parse_result,
+    std::shared_ptr<TiffParseResult> parse_result,
     tensorstore::TimestampedStorageGeneration stamp) {
-  
-  // Get references to the arrays that might need loading
-  auto& entries = parse_result->ifd_entries;
-  auto& img_dir = parse_result->image_directory;
-  
+  ABSL_LOG_IF(INFO, tiff_logging) << "Loading external arrays for key: " << this->key();
   // Collect all external arrays that need to be loaded
   struct ExternalArrayInfo {
     Tag tag;
     TiffDataType type;
     uint64_t offset;
     uint64_t count;
-    std::vector<uint64_t>* output_array;
+    // Instead of a single array, we also track which index in image_directories we belong to.
+    size_t image_index;
+    // We’ll store into either tile_offsets, strip_offsets, etc. based on the tag.
   };
   
   std::vector<ExternalArrayInfo> external_arrays;
-  
-  // Check for strip and tile arrays that need to be loaded
-  for (const auto& entry : entries) {
-    if (!entry.is_external_array) continue;
-    
-    switch (entry.tag) {
-      case Tag::kStripOffsets:
-        external_arrays.push_back({entry.tag, entry.type, entry.value_or_offset, 
-                                 entry.count, &img_dir.strip_offsets});
-        break;
-      case Tag::kStripByteCounts:
-        external_arrays.push_back({entry.tag, entry.type, entry.value_or_offset, 
-                                 entry.count, &img_dir.strip_bytecounts});
-        break;
-      case Tag::kTileOffsets:
-        external_arrays.push_back({entry.tag, entry.type, entry.value_or_offset, 
-                                 entry.count, &img_dir.tile_offsets});
-        break;
-      case Tag::kTileByteCounts:
-        external_arrays.push_back({entry.tag, entry.type, entry.value_or_offset, 
-                                 entry.count, &img_dir.tile_bytecounts});
-        break;
-      default:
-        // Other external arrays aren't needed for the image directory
-        break;
+
+  // Collect external arrays from each directory (and store them by index).
+  for (size_t i = 0; i < parse_result->directories.size(); ++i) {
+    const auto& tiff_dir = parse_result->directories[i];
+
+    for (const auto& entry : tiff_dir.entries) {
+      if (!entry.is_external_array) continue;
+
+      ExternalArrayInfo info;
+      info.tag    = entry.tag;
+      info.type   = entry.type;
+      info.offset = entry.value_or_offset;
+      info.count  = entry.count;
+      info.image_index = i;
+      external_arrays.push_back(info);
     }
   }
-  
-  // If no external arrays to load, return immediately
+
+  // If no external arrays, we can return immediately.
   if (external_arrays.empty()) {
     return MakeReadyFuture<void>();
   }
   
-  ABSL_LOG_IF(INFO, tiff_logging)
-    << "Loading " << external_arrays.size() << " external arrays";
-  
-  // Create a Promise/Future pair to track completion of all array loads
+  // For concurrency, we make a Promise/Future pair to track all loads.
   auto [promise, future] = PromiseFuturePair<void>::Make();
   auto& cache = internal::GetOwningCache(*this);
-  
-  // Track the number of array loads that remain to be processed
+
+  // Track how many arrays remain. We build a small shared struct to handle completion.
   struct LoadState : public internal::AtomicReferenceCount<LoadState> {
     size_t remaining_count;
-    absl::Status status;
-    Promise<void> promise;
-    
-    explicit LoadState(size_t count, Promise<void> promise) 
-        : remaining_count(count), promise(std::move(promise)) {}
-    
+    absl::Status first_error;
+    Promise<void> done_promise;
+
+    LoadState(size_t count, Promise<void> pr)
+        : remaining_count(count), done_promise(std::move(pr)) {}
+
     void CompleteOne(absl::Status s) {
-      if (!s.ok() && status.ok()) {
-        status = s;  // Store the first error encountered
+      if (!s.ok() && first_error.ok()) {
+        first_error = s;  // Record the first error
       }
-      
       if (--remaining_count == 0) {
-        // All operations complete, resolve the promise
-        if (status.ok()) {
-          promise.SetResult(absl::OkStatus());
+        // If we encountered any error, set that; otherwise OK.
+        if (first_error.ok()) {
+          done_promise.SetResult(absl::OkStatus());
         } else {
-          promise.SetResult(status);
+          done_promise.SetResult(first_error);
         }
       }
     }
   };
-  
-  auto load_state = internal::MakeIntrusivePtr<LoadState>(
-      external_arrays.size(), std::move(promise));
-  
-  // Load each external array
+
+  auto load_state = internal::MakeIntrusivePtr<LoadState>(external_arrays.size(), std::move(promise));
+
+  // Issue read operations for each external array in parallel.
   for (const auto& array_info : external_arrays) {
-    // Calculate the byte range needed for this array
+    ABSL_LOG_IF(INFO, tiff_logging) << "Reading external array for tag: " << static_cast<int>(array_info.tag)
+                                    << ", Offset: " << array_info.offset
+                                    << ", Count: " << array_info.count;
+    // Compute the byte range.
     size_t element_size = GetTiffDataTypeSize(array_info.type);
-    size_t byte_count = array_info.count * element_size;
-    
-    // Set up the read options
-    kvstore::ReadOptions options;
-    options.generation_conditions.if_equal = stamp.generation;
-    options.byte_range = OptionalByteRangeRequest::Range(
+    uint64_t byte_count = array_info.count * element_size;
+
+    kvstore::ReadOptions read_opts;
+    read_opts.generation_conditions.if_equal = stamp.generation;
+    read_opts.byte_range = OptionalByteRangeRequest::Range(
         array_info.offset, array_info.offset + byte_count);
-    
+
     ABSL_LOG_IF(INFO, tiff_logging)
-      << "Reading external array for tag " << static_cast<int>(array_info.tag)
-      << " at offset " << array_info.offset << " size " << byte_count;
-    
-    // Issue the read request and track the future
-    auto read_future = cache.kvstore_driver_->Read(std::string(this->key()), options);
+        << "Reading external array for tag " << static_cast<int>(array_info.tag)
+        << " at offset " << array_info.offset << " size " << byte_count;
+
+    auto read_future = cache.kvstore_driver_->Read(std::string(this->key()), read_opts);
     read_future.Force();
     
-    // Process the read result when ready
     read_future.ExecuteWhenReady(
-        [state = load_state, array_info, endian = parse_result->endian](
-            ReadyFuture<kvstore::ReadResult> ready) {
-          auto& r = ready.result();
-          if (!r.ok()) {
-            state->CompleteOne(internal::ConvertInvalidArgumentToFailedPrecondition(r.status()));
+        [ls = load_state, &parse_result, array_info, stamp](
+            ReadyFuture<kvstore::ReadResult> ready) mutable {
+          auto& rr = ready.result();
+          if (!rr.ok()) {
+            ls->CompleteOne(internal::ConvertInvalidArgumentToFailedPrecondition(rr.status()));
             return;
           }
-          
-          auto& read_result = *r;
-          if (read_result.not_found() || read_result.aborted()) {
-            state->CompleteOne(absl::DataLossError(
-                "External array not found or read aborted"));
+
+          if (rr->not_found() || rr->aborted()) {
+            ls->CompleteOne(absl::DataLossError("Missing or aborted external array read."));
             return;
           }
-          
+
+          // We'll parse the data into the image directory’s appropriate field.
+          // Grab the corresponding ImageDirectory.
+          auto& img_dir = parse_result->image_directories[array_info.image_index];
+
           // Create a reader for the data
-          riegeli::CordReader cord_reader(&read_result.value);
-          ABSL_LOG_IF(INFO, tiff_logging)
-              << "Parsing external array for tag " << static_cast<int>(array_info.tag)
-              << " at offset " << array_info.offset << " size " << read_result.value.size();
-              
-          // Parse the external array
-          auto status = ParseExternalArray(
-              cord_reader, endian, 0, array_info.count, 
-              array_info.type, *array_info.output_array);
-              
-          // Complete this array load operation
-          state->CompleteOne(status);
+          riegeli::CordReader cord_reader(&rr->value);
+
+          // We need a temporary buffer (vector<uint64_t>&, etc.) depending on tag:
+          std::vector<uint64_t>* output_array = nullptr;
+          switch (array_info.tag) {
+            case Tag::kStripOffsets:
+              output_array = &img_dir.strip_offsets;
+              break;
+            case Tag::kStripByteCounts:
+              output_array = &img_dir.strip_bytecounts;
+              break;
+            case Tag::kTileOffsets:
+              output_array = &img_dir.tile_offsets;
+              break;
+            case Tag::kTileByteCounts:
+              output_array = &img_dir.tile_bytecounts;
+              break;
+            default:
+              // Possibly skip or store in a custom field if needed
+              break;
+          }
+
+          if (!output_array) {
+            ls->CompleteOne(absl::OkStatus());  // Not needed for this tag
+            return;
+          }
+
+          // Actually parse the external array
+          absl::Status parse_status = ParseExternalArray(
+              cord_reader,
+              parse_result->endian, 
+              /*offset=*/0,
+              array_info.count,
+              array_info.type,
+              *output_array);
+
+          ls->CompleteOne(parse_status);
         });
   }
-  
-  // Return the future that completes when all array loads are finished
+
   return future;
 }
 
@@ -359,7 +565,7 @@ void TiffDirectoryCache::Entry::DoRead(AsyncCacheReadRequest request) {
         lock.read_state().stamp.generation;
   }
 
-  state->StartRead();
+  state->StartTiffRead();
 }
 
 TiffDirectoryCache::Entry* TiffDirectoryCache::DoAllocateEntry() {

--- a/tensorstore/kvstore/tiff/tiff_dir_cache.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache.cc
@@ -362,6 +362,7 @@ struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> 
     // Also check entries for external arrays.
     for (size_t i = 0; i < parse_result_->directories.size(); ++i) {
       // Parse the IFD into parse_result_->image_directories[i].
+      ABSL_LOG(INFO) << "Parsing image metadata from IFD #" << i << " for key: " << entry_->key();
       absl::Status s = ParseImageDirectory(
           parse_result_->directories[i].entries,
           parse_result_->image_directories[i]);

--- a/tensorstore/kvstore/tiff/tiff_dir_cache.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache.cc
@@ -1,0 +1,159 @@
+// Copyright 2025 The TensorStore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tensorstore/kvstore/tiff/tiff_dir_cache.h"
+
+#include <memory>
+
+#include "absl/base/attributes.h"
+#include "absl/log/absl_log.h"
+#include "tensorstore/internal/cache/async_cache.h"
+#include "tensorstore/internal/estimate_heap_usage/estimate_heap_usage.h"
+#include "tensorstore/internal/log/verbose_flag.h"
+#include "tensorstore/kvstore/byte_range.h"
+#include "tensorstore/kvstore/operations.h"
+#include "tensorstore/kvstore/read_result.h"
+#include "tensorstore/util/future.h"
+#include "absl/status/status.h"
+
+namespace tensorstore {
+namespace internal_tiff_kvstore {
+
+namespace {
+
+ABSL_CONST_INIT internal_log::VerboseFlag tiff_logging("tiff");
+
+struct ReadDirectoryOp : public internal::AtomicReferenceCount<ReadDirectoryOp> {
+  TiffDirectoryCache::Entry* entry_;
+  std::shared_ptr<const TiffDirectoryParseResult> existing_read_data_;
+  kvstore::ReadOptions options_;
+  bool is_full_read_;
+
+  void StartRead() {
+    auto& cache = internal::GetOwningCache(*entry_);
+    ABSL_LOG_IF(INFO, tiff_logging)
+        << "StartRead " << entry_->key();
+    
+    // 1.  Default to the “slice‑first” strategy -----------------------------
+    is_full_read_ = false;
+
+    // Honour any *caller‑supplied* range that is smaller than the slice.
+    if (!options_.byte_range.IsFull() &&
+        options_.byte_range.size() <= kInitialReadBytes) {
+      // Caller already requested an explicit (small) range → keep it.
+    } else {
+      // Otherwise issue our standard 0‑1023 probe.
+      options_.byte_range =
+          OptionalByteRangeRequest::Range(0, kInitialReadBytes);
+    }
+
+    auto future = cache.kvstore_driver_->Read(std::string(entry_->key()), options_);
+    future.Force();
+    future.ExecuteWhenReady(
+        [self = internal::IntrusivePtr<ReadDirectoryOp>(this)](
+            ReadyFuture<kvstore::ReadResult> ready) {
+          self->OnReadComplete(std::move(ready));
+        });
+  }
+
+  void OnReadComplete(ReadyFuture<kvstore::ReadResult> ready) {
+    auto& r = ready.result();
+    if (!r.ok()) {
+      // If the ranged request overshot the file, retry with a full read.
+      if (!is_full_read_ && absl::IsOutOfRange(r.status())) {
+      is_full_read_ = true;
+      options_.byte_range = {};  // Full read.
+      auto retry_future =
+          internal::GetOwningCache(*entry_).kvstore_driver_->Read(
+              std::string(entry_->key()), options_);
+      retry_future.Force();
+      retry_future.ExecuteWhenReady(
+          [self = internal::IntrusivePtr<ReadDirectoryOp>(this)](
+              ReadyFuture<kvstore::ReadResult> f) {
+              self->OnReadComplete(std::move(f));
+          });
+      return;
+      }
+      entry_->ReadError(internal::ConvertInvalidArgumentToFailedPrecondition(r.status()));
+      return;
+    }
+
+    auto& read_result = *r;
+    if (read_result.not_found()) {
+      entry_->ReadError(absl::NotFoundError(""));
+      return;
+    }
+
+    if (read_result.aborted()) {
+      // Return existing data if we have it
+      if (existing_read_data_) {
+        entry_->ReadSuccess(TiffDirectoryCache::ReadState{
+            existing_read_data_,
+            std::move(read_result.stamp)
+        });
+        return;
+      }
+      entry_->ReadError(absl::AbortedError("Read aborted"));
+      return;
+    }
+
+    TiffDirectoryParseResult result;
+    result.raw_data = std::move(read_result.value);
+    // If we asked for a slice but got fewer than requested bytes,
+    // we effectively have the whole file.
+    if (!is_full_read_ &&
+          result.raw_data.size() < internal_tiff_kvstore::kInitialReadBytes) {
+        result.full_read = true;
+      } else {
+        result.full_read = is_full_read_;
+      }
+  
+    entry_->ReadSuccess(TiffDirectoryCache::ReadState{
+        std::make_shared<TiffDirectoryParseResult>(std::move(result)),
+        std::move(read_result.stamp)
+    });
+  }
+};
+
+}  // namespace
+
+size_t TiffDirectoryCache::Entry::ComputeReadDataSizeInBytes(
+    const void* read_data) {
+  return static_cast<const ReadData*>(read_data)->raw_data.size();
+}
+
+void TiffDirectoryCache::Entry::DoRead(AsyncCacheReadRequest request) {
+  auto state = internal::MakeIntrusivePtr<ReadDirectoryOp>();
+  state->entry_ = this;
+  state->options_.staleness_bound = request.staleness_bound;
+  {
+    ReadLock<ReadData> lock(*this);
+    state->existing_read_data_ = lock.shared_data();
+    state->options_.generation_conditions.if_not_equal = 
+        lock.read_state().stamp.generation;
+  }
+
+  state->StartRead();
+}
+
+TiffDirectoryCache::Entry* TiffDirectoryCache::DoAllocateEntry() {
+  return new Entry;
+}
+
+size_t TiffDirectoryCache::DoGetSizeofEntry() {
+  return sizeof(Entry);
+}
+
+}  // namespace internal_tiff_kvstore
+}  // namespace tensorstore

--- a/tensorstore/kvstore/tiff/tiff_dir_cache.h
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache.h
@@ -21,7 +21,7 @@
 #include "tensorstore/internal/cache/async_cache.h"
 #include "tensorstore/kvstore/driver.h"
 #include "tensorstore/kvstore/generation.h"
-#include "tensorstore/kvstore/tiff/tiff_details.h"  // Add include for IfdEntry and ImageDirectory
+#include "tensorstore/kvstore/tiff/tiff_details.h"
 #include "tensorstore/util/executor.h"
 
 namespace tensorstore {
@@ -31,9 +31,8 @@ namespace internal_tiff_kvstore {
 inline constexpr std::size_t kInitialReadBytes = 1024;
 
 struct TiffParseResult {
-  // For step-1 this just captures the raw bytes we read.
   absl::Cord raw_data;
-  bool full_read = false;  // identical meaning to zip cache.
+  bool full_read = false; // Indicates if the entire file was read
 
   // Store the endian order for the TIFF file
   Endian endian;

--- a/tensorstore/kvstore/tiff/tiff_dir_cache.h
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache.h
@@ -1,0 +1,69 @@
+// Copyright 2025 The TensorStore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENSORSTORE_KVSTORE_TIFF_TIFF_DIR_CACHE_H_
+#define TENSORSTORE_KVSTORE_TIFF_TIFF_DIR_CACHE_H_
+
+#include <stddef.h>
+
+#include "absl/strings/cord.h"
+#include "tensorstore/internal/cache/async_cache.h"
+#include "tensorstore/kvstore/driver.h"
+#include "tensorstore/util/executor.h"
+
+namespace tensorstore {
+namespace internal_tiff_kvstore {
+
+// First attempt reads this many bytes.
+inline constexpr std::size_t kInitialReadBytes = 1024;
+
+struct TiffDirectoryParseResult {
+  // For step-1 this just captures the raw bytes we read.
+  absl::Cord raw_data;
+  bool full_read = false;  // identical meaning to zip cache.
+};
+
+class TiffDirectoryCache : public internal::AsyncCache {  
+  using Base = internal::AsyncCache;
+ public:
+  using ReadData = TiffDirectoryParseResult;
+
+  explicit TiffDirectoryCache(kvstore::DriverPtr kv, Executor exec)
+      : kvstore_driver_(std::move(kv)), executor_(std::move(exec)) {}
+
+  class Entry : public Base::Entry {
+   public:
+    using OwningCache = TiffDirectoryCache;
+    size_t ComputeReadDataSizeInBytes(const void* read_data) final;
+    void DoRead(AsyncCacheReadRequest request) final;
+  };
+
+  Entry* DoAllocateEntry() final;
+  size_t DoGetSizeofEntry() final;
+
+  TransactionNode* DoAllocateTransactionNode(AsyncCache::Entry& entry) final {
+    ABSL_UNREACHABLE();  // Not implemented for step-1
+    return nullptr;
+  }
+
+  kvstore::DriverPtr kvstore_driver_;
+  Executor executor_;
+
+  const Executor& executor() { return executor_; }
+};
+
+}  // namespace internal_tiff_kvstore
+}  // namespace tensorstore
+
+#endif  // TENSORSTORE_KVSTORE_TIFF_TIFF_DIR_CACHE_H_

--- a/tensorstore/kvstore/tiff/tiff_dir_cache.h
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache.h
@@ -21,6 +21,7 @@
 #include "tensorstore/internal/cache/async_cache.h"
 #include "tensorstore/kvstore/driver.h"
 #include "tensorstore/util/executor.h"
+#include "tensorstore/kvstore/tiff/tiff_details.h"  // Add include for IfdEntry and ImageDirectory
 
 namespace tensorstore {
 namespace internal_tiff_kvstore {
@@ -32,6 +33,10 @@ struct TiffDirectoryParseResult {
   // For step-1 this just captures the raw bytes we read.
   absl::Cord raw_data;
   bool full_read = false;  // identical meaning to zip cache.
+  
+  // Added in step-2c: Parsed TIFF metadata
+  std::vector<IfdEntry> ifd_entries;
+  ImageDirectory image_directory;
 };
 
 class TiffDirectoryCache : public internal::AsyncCache {  

--- a/tensorstore/kvstore/tiff/tiff_dir_cache.h
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache.h
@@ -21,8 +21,8 @@
 #include "tensorstore/internal/cache/async_cache.h"
 #include "tensorstore/kvstore/driver.h"
 #include "tensorstore/kvstore/generation.h"
-#include "tensorstore/util/executor.h"
 #include "tensorstore/kvstore/tiff/tiff_details.h"  // Add include for IfdEntry and ImageDirectory
+#include "tensorstore/util/executor.h"
 
 namespace tensorstore {
 namespace internal_tiff_kvstore {
@@ -34,19 +34,20 @@ struct TiffParseResult {
   // For step-1 this just captures the raw bytes we read.
   absl::Cord raw_data;
   bool full_read = false;  // identical meaning to zip cache.
-  
+
   // Store the endian order for the TIFF file
   Endian endian;
-  
+
   // Store all IFD directories in the TIFF file
   std::vector<TiffDirectory> directories;
-  
+
   // Store all parsed image directories
   std::vector<ImageDirectory> image_directories;
 };
 
-class TiffDirectoryCache : public internal::AsyncCache {  
+class TiffDirectoryCache : public internal::AsyncCache {
   using Base = internal::AsyncCache;
+
  public:
   using ReadData = TiffParseResult;
 
@@ -58,7 +59,7 @@ class TiffDirectoryCache : public internal::AsyncCache {
     using OwningCache = TiffDirectoryCache;
     size_t ComputeReadDataSizeInBytes(const void* read_data) final;
     void DoRead(AsyncCacheReadRequest request) final;
-  
+
     // Load external arrays identified during IFD parsing
     Future<void> LoadExternalArrays(
         std::shared_ptr<TiffParseResult> parse_result,

--- a/tensorstore/kvstore/tiff/tiff_dir_cache.h
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache.h
@@ -31,8 +31,7 @@ namespace internal_tiff_kvstore {
 inline constexpr std::size_t kInitialReadBytes = 1024;
 
 struct TiffParseResult {
-  absl::Cord raw_data;
-  bool full_read = false; // Indicates if the entire file was read
+  bool full_read = false;  // Indicates if the entire file was read
 
   // Store the endian order for the TIFF file
   Endian endian;
@@ -42,6 +41,10 @@ struct TiffParseResult {
 
   // Store all parsed image directories
   std::vector<ImageDirectory> image_directories;
+
+  constexpr static auto ApplyMembers = [](auto&& x, auto f) {
+    return f(x.full_read, x.endian, x.directories, x.image_directories);
+  };
 };
 
 class TiffDirectoryCache : public internal::AsyncCache {

--- a/tensorstore/kvstore/tiff/tiff_dir_cache.h
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache.h
@@ -20,6 +20,7 @@
 #include "absl/strings/cord.h"
 #include "tensorstore/internal/cache/async_cache.h"
 #include "tensorstore/kvstore/driver.h"
+#include "tensorstore/kvstore/generation.h"
 #include "tensorstore/util/executor.h"
 #include "tensorstore/kvstore/tiff/tiff_details.h"  // Add include for IfdEntry and ImageDirectory
 
@@ -37,6 +38,9 @@ struct TiffDirectoryParseResult {
   // Added in step-2c: Parsed TIFF metadata
   std::vector<IfdEntry> ifd_entries;
   ImageDirectory image_directory;
+
+  // Added in step-5: Endian order for the TIFF file
+  Endian endian;
 };
 
 class TiffDirectoryCache : public internal::AsyncCache {  
@@ -52,6 +56,11 @@ class TiffDirectoryCache : public internal::AsyncCache {
     using OwningCache = TiffDirectoryCache;
     size_t ComputeReadDataSizeInBytes(const void* read_data) final;
     void DoRead(AsyncCacheReadRequest request) final;
+  
+    // Load external arrays identified during IFD parsing
+    Future<void> LoadExternalArrays(
+        std::shared_ptr<TiffDirectoryParseResult> parse_result,
+        tensorstore::TimestampedStorageGeneration stamp);
   };
 
   Entry* DoAllocateEntry() final;

--- a/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
@@ -701,4 +701,127 @@ TEST(TiffDirectoryCacheMultiIfdTest, ReadLargeMultiPageTiff) {
   EXPECT_EQ(data->image_directories[1].width, 800);
 }
 
+// ...existing code...
+TEST(TiffDirectoryCacheMultiIfdTest, ExternalArraysMultiIfdTest) {
+  auto context = Context::Default();
+  auto pool = CachePool::Make(CachePool::Limits{});
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      tensorstore::KvStore memory,
+      tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
+
+  // Build a TIFF file with two IFDs, each referencing external arrays
+  std::string tiff_data;
+  tiff_data += "II";                  // Little endian
+  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8); tiff_data.push_back(0);   // First IFD offset
+  tiff_data.push_back(0); tiff_data.push_back(0);
+
+  auto AddEntry = [&](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+    tiff_data.push_back(tag & 0xFF);
+    tiff_data.push_back((tag >> 8) & 0xFF);
+    tiff_data.push_back(type & 0xFF);
+    tiff_data.push_back((type >> 8) & 0xFF);
+    tiff_data.push_back(count & 0xFF);
+    tiff_data.push_back((count >> 8) & 0xFF);
+    tiff_data.push_back((count >> 16) & 0xFF);
+    tiff_data.push_back((count >> 24) & 0xFF);
+    tiff_data.push_back(value & 0xFF);
+    tiff_data.push_back((value >> 8) & 0xFF);
+    tiff_data.push_back((value >> 16) & 0xFF);
+    tiff_data.push_back((value >> 24) & 0xFF);
+  };
+
+  // First IFD with external arrays
+  tiff_data.push_back(5); tiff_data.push_back(0);  // 5 entries
+  AddEntry(256, 3, 1, 400);  // ImageWidth
+  AddEntry(257, 3, 1, 300);  // ImageLength
+  AddEntry(278, 3, 1, 100);  // RowsPerStrip = 100
+  AddEntry(273, 4, 4, 512);  // StripOffsets array (points to offset 512)
+  AddEntry(279, 4, 4, 528);  // StripByteCounts array (points to offset 528)
+
+  // Second IFD offset at 600
+  tiff_data.push_back(0x58); tiff_data.push_back(0x02);
+  tiff_data.push_back(0x00); tiff_data.push_back(0x00);
+
+  // Pad to 512
+  while (tiff_data.size() < 512) tiff_data.push_back('X');
+
+  // External arrays for first IFD (4 entries each)
+  uint32_t offsets1[4] = {1000, 2000, 3000, 4000};
+  for (uint32_t val : offsets1) {
+    for (int i = 0; i < 4; i++) {
+      tiff_data.push_back((val >> (8 * i)) & 0xFF);
+    }
+  }
+  uint32_t bytecounts1[4] = {50, 60, 70, 80};
+  for (uint32_t val : bytecounts1) {
+    for (int i = 0; i < 4; i++) {
+      tiff_data.push_back((val >> (8 * i)) & 0xFF);
+    }
+  }
+
+  // Pad to second IFD offset (600)
+  while (tiff_data.size() < 600) tiff_data.push_back('X');
+
+  // Second IFD with external arrays
+  tiff_data.push_back(6); tiff_data.push_back(0);  // 6 entries
+  AddEntry(256, 3, 1, 800);  // ImageWidth
+  AddEntry(257, 3, 1, 600);  // ImageLength
+  AddEntry(322, 3, 1, 256);  // TileWidth
+  AddEntry(323, 3, 1, 256);  // TileLength
+  AddEntry(324, 4, 4, 700);  // TileOffsets array (offset 700)
+  AddEntry(325, 4, 4, 716);  // TileByteCounts array (offset 716)
+  // No more IFDs
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  tiff_data.push_back(0); tiff_data.push_back(0);
+
+  // Pad to external arrays for second IFD
+  while (tiff_data.size() < 700) tiff_data.push_back('X');
+  uint32_t offsets2[4] = {5000, 5004, 5008, 5012};
+  for (auto val : offsets2) {
+    for (int i = 0; i < 4; i++) {
+      tiff_data.push_back((val >> (8 * i)) & 0xFF);
+    }
+  }
+  uint32_t bytecounts2[4] = {100, 200, 300, 400};
+  for (auto val : bytecounts2) {
+    for (int i = 0; i < 4; i++) {
+      tiff_data.push_back((val >> (8 * i)) & 0xFF);
+    }
+  }
+
+  // Write the file
+  ASSERT_THAT(
+      tensorstore::kvstore::Write(memory, "multi_ifd_external.tiff", absl::Cord(tiff_data))
+          .result(),
+      ::tensorstore::IsOk());
+
+  // Read back with TiffDirectoryCache
+  auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
+    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+  });
+  auto entry = GetCacheEntry(cache, "multi_ifd_external.tiff");
+  tensorstore::internal::AsyncCache::AsyncCacheReadRequest request;
+  request.staleness_bound = absl::InfinitePast();
+
+  ASSERT_THAT(entry->Read(request).result(), ::tensorstore::IsOk());
+
+  TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(*entry);
+  auto* data = lock.data();
+  ASSERT_THAT(data, ::testing::NotNull());
+
+  // Expect two IFDs
+  EXPECT_EQ(data->directories.size(), 2);
+  EXPECT_EQ(data->image_directories.size(), 2);
+
+  // Check external arrays in IFD #1
+  EXPECT_EQ(data->image_directories[0].strip_offsets.size(), 4);
+  EXPECT_EQ(data->image_directories[0].strip_bytecounts.size(), 4);
+
+  // Check external arrays in IFD #2
+  // (Tile offsets and bytecounts are stored, but the key is that they got parsed)
+  EXPECT_EQ(data->image_directories[1].tile_offsets.size(), 4);
+  EXPECT_EQ(data->image_directories[1].tile_bytecounts.size(), 4);
+}
+
 }  // namespace

--- a/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
@@ -14,11 +14,12 @@
 
 #include "tensorstore/kvstore/tiff/tiff_dir_cache.h"
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <memory>
 #include <string>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include "absl/strings/cord.h"
 #include "absl/time/time.h"
 #include "tensorstore/context.h"
@@ -38,7 +39,6 @@ using ::tensorstore::internal::CachePool;
 using ::tensorstore::internal::GetCache;
 using ::tensorstore::internal_tiff_kvstore::TiffDirectoryCache;
 
-
 TEST(TiffDirectoryCacheTest, ReadSlice) {
   auto context = Context::Default();
   auto pool = CachePool::Make(CachePool::Limits{});
@@ -50,18 +50,23 @@ TEST(TiffDirectoryCacheTest, ReadSlice) {
 
   // Create a small TIFF file with a valid header and IFD
   std::string tiff_data;
-  
+
   // TIFF header (8 bytes)
-  tiff_data += "II";                           // Little endian
-  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
-  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data += "II";  // Little endian
+  tiff_data.push_back(42);
+  tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8);
+  tiff_data.push_back(0);  // IFD offset (8)
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // IFD with 5 entries
-  tiff_data.push_back(6); tiff_data.push_back(0);  // 5 entries
-  
+  tiff_data.push_back(6);
+  tiff_data.push_back(0);  // 5 entries
+
   // Helper to add an IFD entry
-  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count,
+                               uint32_t value) {
     tiff_data.push_back(tag & 0xFF);
     tiff_data.push_back((tag >> 8) & 0xFF);
     tiff_data.push_back(type & 0xFF);
@@ -75,21 +80,23 @@ TEST(TiffDirectoryCacheTest, ReadSlice) {
     tiff_data.push_back((value >> 16) & 0xFF);
     tiff_data.push_back((value >> 24) & 0xFF);
   };
-  
+
   // Width and height
   AddEntry(256, 3, 1, 800);  // ImageWidth = 800
   AddEntry(257, 3, 1, 600);  // ImageLength = 600
-  
+
   // Tile info
   AddEntry(322, 3, 1, 256);  // TileWidth = 256
   AddEntry(323, 3, 1, 256);  // TileLength = 256
   AddEntry(324, 4, 1, 128);  // TileOffsets = 128
   AddEntry(325, 4, 1, 256);  // TileByteCounts = 256
-  
+
   // No more IFDs
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // Pad to 2048 bytes (more than kInitialReadBytes)
   while (tiff_data.size() < 2048) {
     tiff_data.push_back('X');
@@ -101,7 +108,8 @@ TEST(TiffDirectoryCacheTest, ReadSlice) {
       ::tensorstore::IsOk());
 
   auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
-    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+    return std::make_unique<TiffDirectoryCache>(memory.driver,
+                                                InlineExecutor{});
   });
 
   auto entry = GetCacheEntry(cache, "test.tiff");
@@ -117,13 +125,13 @@ TEST(TiffDirectoryCacheTest, ReadSlice) {
     auto* data = lock.data();
     ASSERT_THAT(data, ::testing::NotNull());
     EXPECT_FALSE(data->full_read);
-    
+
     // Check parsed directories
     EXPECT_EQ(data->directories.size(), 1);
     EXPECT_EQ(data->directories[0].entries.size(), 6);
     EXPECT_EQ(data->image_directories.size(), 1);
-    
-    // Check parsed image directory 
+
+    // Check parsed image directory
     EXPECT_EQ(data->image_directories[0].width, 800);
     EXPECT_EQ(data->image_directories[0].height, 600);
     EXPECT_EQ(data->image_directories[0].tile_width, 256);
@@ -140,20 +148,26 @@ TEST(TiffDirectoryCacheTest, ReadFull) {
       tensorstore::KvStore memory,
       tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
 
-  // Create a small TIFF file with a valid header and IFD - similar to above but smaller
+  // Create a small TIFF file with a valid header and IFD - similar to above but
+  // smaller
   std::string tiff_data;
-  
+
   // TIFF header (8 bytes)
-  tiff_data += "II";                              // Little endian
-  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
-  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data += "II";  // Little endian
+  tiff_data.push_back(42);
+  tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8);
+  tiff_data.push_back(0);  // IFD offset (8)
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // IFD with 5 entries
-  tiff_data.push_back(5); tiff_data.push_back(0);  // 5 entries
-  
+  tiff_data.push_back(5);
+  tiff_data.push_back(0);  // 5 entries
+
   // Helper to add an IFD entry
-  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count,
+                               uint32_t value) {
     tiff_data.push_back(tag & 0xFF);
     tiff_data.push_back((tag >> 8) & 0xFF);
     tiff_data.push_back(type & 0xFF);
@@ -167,18 +181,20 @@ TEST(TiffDirectoryCacheTest, ReadFull) {
     tiff_data.push_back((value >> 16) & 0xFF);
     tiff_data.push_back((value >> 24) & 0xFF);
   };
-  
-  // Add strip-based entries 
+
+  // Add strip-based entries
   AddEntry(256, 3, 1, 400);  // ImageWidth = 400
   AddEntry(257, 3, 1, 300);  // ImageLength = 300
   AddEntry(278, 3, 1, 100);  // RowsPerStrip = 100
   AddEntry(273, 4, 1, 128);  // StripOffsets = 128
   AddEntry(279, 4, 1, 200);  // StripByteCounts = 200
-  
+
   // No more IFDs
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // Pad to fill data
   while (tiff_data.size() < 512) {
     tiff_data.push_back('X');
@@ -190,7 +206,8 @@ TEST(TiffDirectoryCacheTest, ReadFull) {
       ::tensorstore::IsOk());
 
   auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
-    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+    return std::make_unique<TiffDirectoryCache>(memory.driver,
+                                                InlineExecutor{});
   });
 
   auto entry = GetCacheEntry(cache, "test.tiff");
@@ -206,12 +223,12 @@ TEST(TiffDirectoryCacheTest, ReadFull) {
     auto* data = lock.data();
     ASSERT_THAT(data, ::testing::NotNull());
     EXPECT_TRUE(data->full_read);
-    
+
     // Check parsed directories
     EXPECT_EQ(data->directories.size(), 1);
     EXPECT_EQ(data->directories[0].entries.size(), 5);
     EXPECT_EQ(data->image_directories.size(), 1);
-    
+
     // Check parsed image directory
     EXPECT_EQ(data->image_directories[0].width, 400);
     EXPECT_EQ(data->image_directories[0].height, 300);
@@ -234,31 +251,42 @@ TEST(TiffDirectoryCacheTest, BadIfdFailsParse) {
 
   // Create a corrupt TIFF file with invalid IFD
   std::string corrupt_tiff;
-  
-  // Valid TIFF header
-  corrupt_tiff += "II";                              // Little endian
-  corrupt_tiff.push_back(42); corrupt_tiff.push_back(0);  // Magic number
-  corrupt_tiff.push_back(8); corrupt_tiff.push_back(0);   // IFD offset (8)
-  corrupt_tiff.push_back(0); corrupt_tiff.push_back(0);
-  
-  // Corrupt IFD - claim 10 entries but only provide data for 1
-  corrupt_tiff.push_back(10); corrupt_tiff.push_back(0);  // 10 entries (too many)
-  
-  // Only one entry (not enough data for 10)
-  corrupt_tiff.push_back(1); corrupt_tiff.push_back(1);   // tag
-  corrupt_tiff.push_back(1); corrupt_tiff.push_back(0);   // type
-  corrupt_tiff.push_back(1); corrupt_tiff.push_back(0);   // count
-  corrupt_tiff.push_back(0); corrupt_tiff.push_back(0);
-  corrupt_tiff.push_back(0); corrupt_tiff.push_back(0);   // value
-  corrupt_tiff.push_back(0); corrupt_tiff.push_back(0);
 
-  ASSERT_THAT(
-      tensorstore::kvstore::Write(memory, "corrupt.tiff", absl::Cord(corrupt_tiff))
-          .result(),
-      ::tensorstore::IsOk());
+  // Valid TIFF header
+  corrupt_tiff += "II";  // Little endian
+  corrupt_tiff.push_back(42);
+  corrupt_tiff.push_back(0);  // Magic number
+  corrupt_tiff.push_back(8);
+  corrupt_tiff.push_back(0);  // IFD offset (8)
+  corrupt_tiff.push_back(0);
+  corrupt_tiff.push_back(0);
+
+  // Corrupt IFD - claim 10 entries but only provide data for 1
+  corrupt_tiff.push_back(10);
+  corrupt_tiff.push_back(0);  // 10 entries (too many)
+
+  // Only one entry (not enough data for 10)
+  corrupt_tiff.push_back(1);
+  corrupt_tiff.push_back(1);  // tag
+  corrupt_tiff.push_back(1);
+  corrupt_tiff.push_back(0);  // type
+  corrupt_tiff.push_back(1);
+  corrupt_tiff.push_back(0);  // count
+  corrupt_tiff.push_back(0);
+  corrupt_tiff.push_back(0);
+  corrupt_tiff.push_back(0);
+  corrupt_tiff.push_back(0);  // value
+  corrupt_tiff.push_back(0);
+  corrupt_tiff.push_back(0);
+
+  ASSERT_THAT(tensorstore::kvstore::Write(memory, "corrupt.tiff",
+                                          absl::Cord(corrupt_tiff))
+                  .result(),
+              ::tensorstore::IsOk());
 
   auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
-    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+    return std::make_unique<TiffDirectoryCache>(memory.driver,
+                                                InlineExecutor{});
   });
 
   auto entry = GetCacheEntry(cache, "corrupt.tiff");
@@ -269,7 +297,7 @@ TEST(TiffDirectoryCacheTest, BadIfdFailsParse) {
   // Reading should fail due to corrupt IFD
   auto read_result = entry->Read(request).result();
   EXPECT_THAT(read_result.status(), ::testing::Not(::tensorstore::IsOk()));
-  EXPECT_TRUE(absl::IsDataLoss(read_result.status()) || 
+  EXPECT_TRUE(absl::IsDataLoss(read_result.status()) ||
               absl::IsInvalidArgument(read_result.status()));
 }
 
@@ -284,18 +312,23 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_EagerLoad) {
 
   // Create a TIFF file with external array references
   std::string tiff_data;
-  
+
   // TIFF header (8 bytes)
-  tiff_data += "II";                           // Little endian
-  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
-  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data += "II";  // Little endian
+  tiff_data.push_back(42);
+  tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8);
+  tiff_data.push_back(0);  // IFD offset (8)
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // IFD with 5 entries
-  tiff_data.push_back(5); tiff_data.push_back(0);  // 5 entries
-  
+  tiff_data.push_back(5);
+  tiff_data.push_back(0);  // 5 entries
+
   // Helper to add an IFD entry
-  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count,
+                               uint32_t value) {
     tiff_data.push_back(tag & 0xFF);
     tiff_data.push_back((tag >> 8) & 0xFF);
     tiff_data.push_back(type & 0xFF);
@@ -309,29 +342,34 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_EagerLoad) {
     tiff_data.push_back((value >> 16) & 0xFF);
     tiff_data.push_back((value >> 24) & 0xFF);
   };
-  
+
   // Basic image info
   AddEntry(256, 3, 1, 800);  // ImageWidth = 800
   AddEntry(257, 3, 1, 600);  // ImageLength = 600
   AddEntry(278, 3, 1, 100);  // RowsPerStrip = 100
-  
+
   // External strip offsets array (4 strips)
-  uint32_t strip_offsets_offset = 200; // Position of external array in file
-  AddEntry(273, 4, 4, strip_offsets_offset);  // StripOffsets - points to external array
-  
+  uint32_t strip_offsets_offset = 200;  // Position of external array in file
+  AddEntry(273, 4, 4,
+           strip_offsets_offset);  // StripOffsets - points to external array
+
   // External strip bytecounts array (4 strips)
-  uint32_t strip_bytecounts_offset = 216; // Position of external array in file
-  AddEntry(279, 4, 4, strip_bytecounts_offset);  // StripByteCounts - points to external array
-  
+  uint32_t strip_bytecounts_offset = 216;  // Position of external array in file
+  AddEntry(
+      279, 4, 4,
+      strip_bytecounts_offset);  // StripByteCounts - points to external array
+
   // No more IFDs
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // Pad to 200 bytes to reach strip_offsets_offset
   while (tiff_data.size() < strip_offsets_offset) {
     tiff_data.push_back('X');
   }
-  
+
   // Write the strip offsets external array (4 strips)
   uint32_t strip_offsets[4] = {1000, 2000, 3000, 4000};
   for (uint32_t offset : strip_offsets) {
@@ -340,7 +378,7 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_EagerLoad) {
     tiff_data.push_back((offset >> 16) & 0xFF);
     tiff_data.push_back((offset >> 24) & 0xFF);
   }
-  
+
   // Write the strip bytecounts external array (4 strips)
   uint32_t strip_bytecounts[4] = {500, 600, 700, 800};
   for (uint32_t bytecount : strip_bytecounts) {
@@ -349,19 +387,20 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_EagerLoad) {
     tiff_data.push_back((bytecount >> 16) & 0xFF);
     tiff_data.push_back((bytecount >> 24) & 0xFF);
   }
-  
+
   // Pad the file to ensure it's large enough
   while (tiff_data.size() < 4096) {
     tiff_data.push_back('X');
   }
 
-  ASSERT_THAT(
-      tensorstore::kvstore::Write(memory, "external_arrays.tiff", absl::Cord(tiff_data))
-          .result(),
-      ::tensorstore::IsOk());
+  ASSERT_THAT(tensorstore::kvstore::Write(memory, "external_arrays.tiff",
+                                          absl::Cord(tiff_data))
+                  .result(),
+              ::tensorstore::IsOk());
 
   auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
-    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+    return std::make_unique<TiffDirectoryCache>(memory.driver,
+                                                InlineExecutor{});
   });
 
   auto entry = GetCacheEntry(cache, "external_arrays.tiff");
@@ -376,15 +415,16 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_EagerLoad) {
     TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(*entry);
     auto* data = lock.data();
     ASSERT_THAT(data, ::testing::NotNull());
-    
+
     // Check that external arrays were loaded
     EXPECT_EQ(data->image_directories[0].strip_offsets.size(), 4);
     EXPECT_EQ(data->image_directories[0].strip_bytecounts.size(), 4);
-    
+
     // Verify the external array values were loaded correctly
     for (int i = 0; i < 4; i++) {
       EXPECT_EQ(data->image_directories[0].strip_offsets[i], strip_offsets[i]);
-      EXPECT_EQ(data->image_directories[0].strip_bytecounts[i], strip_bytecounts[i]);
+      EXPECT_EQ(data->image_directories[0].strip_bytecounts[i],
+                strip_bytecounts[i]);
     }
   }
 }
@@ -400,18 +440,23 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_BadPointer) {
 
   // Create a TIFF file with an invalid external array reference
   std::string tiff_data;
-  
+
   // TIFF header (8 bytes)
-  tiff_data += "II";                           // Little endian
-  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
-  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data += "II";  // Little endian
+  tiff_data.push_back(42);
+  tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8);
+  tiff_data.push_back(0);  // IFD offset (8)
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // IFD with 5 entries
-  tiff_data.push_back(5); tiff_data.push_back(0);  // 5 entries
-  
+  tiff_data.push_back(5);
+  tiff_data.push_back(0);  // 5 entries
+
   // Helper to add an IFD entry
-  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count,
+                               uint32_t value) {
     tiff_data.push_back(tag & 0xFF);
     tiff_data.push_back((tag >> 8) & 0xFF);
     tiff_data.push_back(type & 0xFF);
@@ -425,35 +470,39 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_BadPointer) {
     tiff_data.push_back((value >> 16) & 0xFF);
     tiff_data.push_back((value >> 24) & 0xFF);
   };
-  
+
   // Basic image info
   AddEntry(256, 3, 1, 800);  // ImageWidth = 800
   AddEntry(257, 3, 1, 600);  // ImageLength = 600
   AddEntry(278, 3, 1, 100);  // RowsPerStrip = 100
-  
+
   // External strip offsets array with INVALID OFFSET - points beyond file end
   uint32_t invalid_offset = 50000;  // Far beyond our file size
-  AddEntry(273, 4, 4, invalid_offset);  // StripOffsets - points to invalid location
-  
+  AddEntry(273, 4, 4,
+           invalid_offset);  // StripOffsets - points to invalid location
+
   // Valid strip bytecounts
   AddEntry(279, 4, 1, 500);  // StripByteCounts - inline value
-  
+
   // No more IFDs
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // Pad the file to a reasonable size, but less than invalid_offset
   while (tiff_data.size() < 1000) {
     tiff_data.push_back('X');
   }
 
-  ASSERT_THAT(
-      tensorstore::kvstore::Write(memory, "bad_external_array.tiff", absl::Cord(tiff_data))
-          .result(),
-      ::tensorstore::IsOk());
+  ASSERT_THAT(tensorstore::kvstore::Write(memory, "bad_external_array.tiff",
+                                          absl::Cord(tiff_data))
+                  .result(),
+              ::tensorstore::IsOk());
 
   auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
-    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+    return std::make_unique<TiffDirectoryCache>(memory.driver,
+                                                InlineExecutor{});
   });
 
   auto entry = GetCacheEntry(cache, "bad_external_array.tiff");
@@ -464,10 +513,10 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_BadPointer) {
 
   auto read_result = entry->Read(request).result();
   EXPECT_THAT(read_result.status(), ::testing::Not(::tensorstore::IsOk()));
-  
+
   std::cout << "Status: " << read_result.status() << std::endl;
   // Should fail with OutOfRange, InvalidArgument, or DataLoss error
-  EXPECT_TRUE(absl::IsOutOfRange(read_result.status()) || 
+  EXPECT_TRUE(absl::IsOutOfRange(read_result.status()) ||
               absl::IsDataLoss(read_result.status()) ||
               absl::IsInvalidArgument(read_result.status()) ||
               absl::IsFailedPrecondition(read_result.status()));
@@ -476,15 +525,19 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_BadPointer) {
 // Helper to create a test TIFF file with multiple IFDs
 std::string MakeMultiPageTiff() {
   std::string tiff_data;
-  
+
   // TIFF header (8 bytes)
-  tiff_data += "II";                           // Little endian
-  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
-  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data += "II";  // Little endian
+  tiff_data.push_back(42);
+  tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8);
+  tiff_data.push_back(0);  // IFD offset (8)
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // Helper to add an IFD entry
-  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count,
+                               uint32_t value) {
     tiff_data.push_back(tag & 0xFF);
     tiff_data.push_back((tag >> 8) & 0xFF);
     tiff_data.push_back(type & 0xFF);
@@ -500,44 +553,50 @@ std::string MakeMultiPageTiff() {
   };
 
   // First IFD at offset 8
-  tiff_data.push_back(5); tiff_data.push_back(0);  // 5 entries
-  
+  tiff_data.push_back(5);
+  tiff_data.push_back(0);  // 5 entries
+
   // Add strip-based entries for first IFD
-  AddEntry(256, 3, 1, 400);  // ImageWidth = 400
-  AddEntry(257, 3, 1, 300);  // ImageLength = 300
-  AddEntry(278, 3, 1, 100);  // RowsPerStrip = 100
+  AddEntry(256, 3, 1, 400);   // ImageWidth = 400
+  AddEntry(257, 3, 1, 300);   // ImageLength = 300
+  AddEntry(278, 3, 1, 100);   // RowsPerStrip = 100
   AddEntry(273, 4, 1, 1000);  // StripOffsets = 1000
-  AddEntry(279, 4, 1, 200);  // StripByteCounts = 200
-  
+  AddEntry(279, 4, 1, 200);   // StripByteCounts = 200
+
   // Point to second IFD at offset 200
-  tiff_data.push_back(200); tiff_data.push_back(0);
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data.push_back(200);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // Pad to second IFD offset
   while (tiff_data.size() < 200) {
     tiff_data.push_back('X');
   }
-  
+
   // Second IFD
-  tiff_data.push_back(6); tiff_data.push_back(0);  // 6 entries
-  
+  tiff_data.push_back(6);
+  tiff_data.push_back(0);  // 6 entries
+
   // Add tile-based entries for second IFD
-  AddEntry(256, 3, 1, 800);  // ImageWidth = 800
-  AddEntry(257, 3, 1, 600);  // ImageLength = 600
-  AddEntry(322, 3, 1, 256);  // TileWidth = 256
-  AddEntry(323, 3, 1, 256);  // TileLength = 256
+  AddEntry(256, 3, 1, 800);   // ImageWidth = 800
+  AddEntry(257, 3, 1, 600);   // ImageLength = 600
+  AddEntry(322, 3, 1, 256);   // TileWidth = 256
+  AddEntry(323, 3, 1, 256);   // TileLength = 256
   AddEntry(324, 4, 1, 2000);  // TileOffsets
   AddEntry(325, 4, 1, 300);   // TileByteCounts (needed for tile-based IFD)
-  
+
   // No more IFDs
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // Pad file to cover all offsets
   while (tiff_data.size() < 3000) {
     tiff_data.push_back('X');
   }
-  
+
   return tiff_data;
 }
 
@@ -550,14 +609,14 @@ TEST(TiffDirectoryCacheMultiIfdTest, ReadAndVerifyIFDs) {
       tensorstore::KvStore memory,
       tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
 
-  ASSERT_THAT(
-      tensorstore::kvstore::Write(memory, "multi_ifd.tiff", 
-                                 absl::Cord(MakeMultiPageTiff()))
-          .result(),
-      ::tensorstore::IsOk());
+  ASSERT_THAT(tensorstore::kvstore::Write(memory, "multi_ifd.tiff",
+                                          absl::Cord(MakeMultiPageTiff()))
+                  .result(),
+              ::tensorstore::IsOk());
 
   auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
-    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+    return std::make_unique<TiffDirectoryCache>(memory.driver,
+                                                InlineExecutor{});
   });
 
   auto entry = GetCacheEntry(cache, "multi_ifd.tiff");
@@ -586,7 +645,7 @@ TEST(TiffDirectoryCacheMultiIfdTest, ReadAndVerifyIFDs) {
   EXPECT_EQ(img1.strip_offsets.size(), 1);
   EXPECT_EQ(img1.strip_offsets[0], 1000);
   EXPECT_EQ(img1.strip_bytecounts[0], 200);
-  
+
   // Check second IFD (tile-based)
   const auto& ifd2 = data->directories[1];
   const auto& img2 = data->image_directories[1];
@@ -597,7 +656,7 @@ TEST(TiffDirectoryCacheMultiIfdTest, ReadAndVerifyIFDs) {
   EXPECT_EQ(img2.tile_height, 256);
   EXPECT_EQ(img2.tile_offsets.size(), 1);
   EXPECT_EQ(img2.tile_offsets[0], 2000);
-  
+
   // Since our test file is larger than kInitialReadBytes (1024),
   // it should be not be fully read in one shot
   EXPECT_FALSE(data->full_read);
@@ -614,14 +673,18 @@ TEST(TiffDirectoryCacheMultiIfdTest, ReadLargeMultiPageTiff) {
 
   // Create a TIFF file larger than kInitialReadBytes
   std::string tiff_data;
-  
+
   // TIFF header (8 bytes)
-  tiff_data += "II";                           // Little endian
-  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
-  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
-  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+  tiff_data += "II";  // Little endian
+  tiff_data.push_back(42);
+  tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8);
+  tiff_data.push_back(0);  // IFD offset (8)
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count,
+                               uint32_t value) {
     tiff_data.push_back(tag & 0xFF);
     tiff_data.push_back((tag >> 8) & 0xFF);
     tiff_data.push_back(type & 0xFF);
@@ -637,48 +700,54 @@ TEST(TiffDirectoryCacheMultiIfdTest, ReadLargeMultiPageTiff) {
   };
 
   // First IFD
-  tiff_data.push_back(5); tiff_data.push_back(0);  // 5 entries
-  AddEntry(256, 3, 1, 400);  // ImageWidth = 400 
-  AddEntry(257, 3, 1, 300);  // ImageLength = 300
-  AddEntry(278, 3, 1, 100);  // RowsPerStrip = 100
-  AddEntry(273, 4, 1, 1024); // StripOffsets = 1024 (just after initial read)
-  AddEntry(279, 4, 1, 200);  // StripByteCounts = 200
-  
+  tiff_data.push_back(5);
+  tiff_data.push_back(0);     // 5 entries
+  AddEntry(256, 3, 1, 400);   // ImageWidth = 400
+  AddEntry(257, 3, 1, 300);   // ImageLength = 300
+  AddEntry(278, 3, 1, 100);   // RowsPerStrip = 100
+  AddEntry(273, 4, 1, 1024);  // StripOffsets = 1024 (just after initial read)
+  AddEntry(279, 4, 1, 200);   // StripByteCounts = 200
+
   // Point to second IFD at offset 2048 (well beyond initial read)
-  tiff_data.push_back(0x00); tiff_data.push_back(0x08);
-  tiff_data.push_back(0x00); tiff_data.push_back(0x00);
-  
+  tiff_data.push_back(0x00);
+  tiff_data.push_back(0x08);
+  tiff_data.push_back(0x00);
+  tiff_data.push_back(0x00);
+
   // Pad to second IFD offset
   while (tiff_data.size() < 2048) {
     tiff_data.push_back('X');
   }
-  
+
   // Second IFD
-  tiff_data.push_back(6); tiff_data.push_back(0);  // 6 entries
-  AddEntry(256, 3, 1, 800);  // ImageWidth = 800
-  AddEntry(257, 3, 1, 600);  // ImageLength = 600
-  AddEntry(322, 3, 1, 256);  // TileWidth = 256
-  AddEntry(323, 3, 1, 256);  // TileLength = 256
-  AddEntry(324, 4, 1, 3000); // TileOffsets
-  AddEntry(325, 4, 1, 300);  // TileByteCounts (needed for tile-based IFD)
-  
+  tiff_data.push_back(6);
+  tiff_data.push_back(0);     // 6 entries
+  AddEntry(256, 3, 1, 800);   // ImageWidth = 800
+  AddEntry(257, 3, 1, 600);   // ImageLength = 600
+  AddEntry(322, 3, 1, 256);   // TileWidth = 256
+  AddEntry(323, 3, 1, 256);   // TileLength = 256
+  AddEntry(324, 4, 1, 3000);  // TileOffsets
+  AddEntry(325, 4, 1, 300);   // TileByteCounts (needed for tile-based IFD)
+
   // No more IFDs
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // Pad file to cover all offsets
   while (tiff_data.size() < 4096) {
     tiff_data.push_back('X');
   }
 
-  ASSERT_THAT(
-      tensorstore::kvstore::Write(memory, "large_multi_ifd.tiff", 
-                                 absl::Cord(tiff_data))
-          .result(),
-      ::tensorstore::IsOk());
+  ASSERT_THAT(tensorstore::kvstore::Write(memory, "large_multi_ifd.tiff",
+                                          absl::Cord(tiff_data))
+                  .result(),
+              ::tensorstore::IsOk());
 
   auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
-    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+    return std::make_unique<TiffDirectoryCache>(memory.driver,
+                                                InlineExecutor{});
   });
 
   auto entry = GetCacheEntry(cache, "large_multi_ifd.tiff");
@@ -710,12 +779,16 @@ TEST(TiffDirectoryCacheMultiIfdTest, ExternalArraysMultiIfdTest) {
 
   // Build a TIFF file with two IFDs, each referencing external arrays
   std::string tiff_data;
-  tiff_data += "II";                  // Little endian
-  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
-  tiff_data.push_back(8); tiff_data.push_back(0);   // First IFD offset
-  tiff_data.push_back(0); tiff_data.push_back(0);
+  tiff_data += "II";  // Little endian
+  tiff_data.push_back(42);
+  tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8);
+  tiff_data.push_back(0);  // First IFD offset
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
 
-  auto AddEntry = [&](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+  auto AddEntry = [&](uint16_t tag, uint16_t type, uint32_t count,
+                      uint32_t value) {
     tiff_data.push_back(tag & 0xFF);
     tiff_data.push_back((tag >> 8) & 0xFF);
     tiff_data.push_back(type & 0xFF);
@@ -731,7 +804,8 @@ TEST(TiffDirectoryCacheMultiIfdTest, ExternalArraysMultiIfdTest) {
   };
 
   // First IFD with external arrays
-  tiff_data.push_back(5); tiff_data.push_back(0);  // 5 entries
+  tiff_data.push_back(5);
+  tiff_data.push_back(0);    // 5 entries
   AddEntry(256, 3, 1, 400);  // ImageWidth
   AddEntry(257, 3, 1, 300);  // ImageLength
   AddEntry(278, 3, 1, 100);  // RowsPerStrip = 100
@@ -739,8 +813,10 @@ TEST(TiffDirectoryCacheMultiIfdTest, ExternalArraysMultiIfdTest) {
   AddEntry(279, 4, 4, 528);  // StripByteCounts array (points to offset 528)
 
   // Second IFD offset at 600
-  tiff_data.push_back(0x58); tiff_data.push_back(0x02);
-  tiff_data.push_back(0x00); tiff_data.push_back(0x00);
+  tiff_data.push_back(0x58);
+  tiff_data.push_back(0x02);
+  tiff_data.push_back(0x00);
+  tiff_data.push_back(0x00);
 
   // Pad to 512
   while (tiff_data.size() < 512) tiff_data.push_back('X');
@@ -763,7 +839,8 @@ TEST(TiffDirectoryCacheMultiIfdTest, ExternalArraysMultiIfdTest) {
   while (tiff_data.size() < 600) tiff_data.push_back('X');
 
   // Second IFD with external arrays
-  tiff_data.push_back(6); tiff_data.push_back(0);  // 6 entries
+  tiff_data.push_back(6);
+  tiff_data.push_back(0);    // 6 entries
   AddEntry(256, 3, 1, 800);  // ImageWidth
   AddEntry(257, 3, 1, 600);  // ImageLength
   AddEntry(322, 3, 1, 256);  // TileWidth
@@ -771,8 +848,10 @@ TEST(TiffDirectoryCacheMultiIfdTest, ExternalArraysMultiIfdTest) {
   AddEntry(324, 4, 4, 700);  // TileOffsets array (offset 700)
   AddEntry(325, 4, 4, 716);  // TileByteCounts array (offset 716)
   // No more IFDs
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  tiff_data.push_back(0); tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
 
   // Pad to external arrays for second IFD
   while (tiff_data.size() < 700) tiff_data.push_back('X');
@@ -790,14 +869,15 @@ TEST(TiffDirectoryCacheMultiIfdTest, ExternalArraysMultiIfdTest) {
   }
 
   // Write the file
-  ASSERT_THAT(
-      tensorstore::kvstore::Write(memory, "multi_ifd_external.tiff", absl::Cord(tiff_data))
-          .result(),
-      ::tensorstore::IsOk());
+  ASSERT_THAT(tensorstore::kvstore::Write(memory, "multi_ifd_external.tiff",
+                                          absl::Cord(tiff_data))
+                  .result(),
+              ::tensorstore::IsOk());
 
   // Read back with TiffDirectoryCache
   auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
-    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+    return std::make_unique<TiffDirectoryCache>(memory.driver,
+                                                InlineExecutor{});
   });
   auto entry = GetCacheEntry(cache, "multi_ifd_external.tiff");
   tensorstore::internal::AsyncCache::AsyncCacheReadRequest request;
@@ -818,7 +898,8 @@ TEST(TiffDirectoryCacheMultiIfdTest, ExternalArraysMultiIfdTest) {
   EXPECT_EQ(data->image_directories[0].strip_bytecounts.size(), 4);
 
   // Check external arrays in IFD #2
-  // (Tile offsets and bytecounts are stored, but the key is that they got parsed)
+  // (Tile offsets and bytecounts are stored, but the key is that they got
+  // parsed)
   EXPECT_EQ(data->image_directories[1].tile_offsets.size(), 4);
   EXPECT_EQ(data->image_directories[1].tile_bytecounts.size(), 4);
 }
@@ -832,20 +913,26 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_Uint16Arrays) {
       tensorstore::KvStore memory,
       tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
 
-  // Create a TIFF file with uint16_t external arrays (BitsPerSample and SampleFormat)
+  // Create a TIFF file with uint16_t external arrays (BitsPerSample and
+  // SampleFormat)
   std::string tiff_data;
-  
+
   // TIFF header (8 bytes)
-  tiff_data += "II";                           // Little endian
-  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
-  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data += "II";  // Little endian
+  tiff_data.push_back(42);
+  tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8);
+  tiff_data.push_back(0);  // IFD offset (8)
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // IFD with 8 entries
-  tiff_data.push_back(8); tiff_data.push_back(0);  // 8 entries
-  
+  tiff_data.push_back(8);
+  tiff_data.push_back(0);  // 8 entries
+
   // Helper to add an IFD entry
-  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count,
+                               uint32_t value) {
     tiff_data.push_back(tag & 0xFF);
     tiff_data.push_back((tag >> 8) & 0xFF);
     tiff_data.push_back(type & 0xFF);
@@ -859,65 +946,69 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_Uint16Arrays) {
     tiff_data.push_back((value >> 16) & 0xFF);
     tiff_data.push_back((value >> 24) & 0xFF);
   };
-  
+
   // Basic image info
   AddEntry(256, 3, 1, 800);  // ImageWidth = 800
   AddEntry(257, 3, 1, 600);  // ImageLength = 600
   AddEntry(277, 3, 1, 3);    // SamplesPerPixel = 3 (RGB)
   AddEntry(278, 3, 1, 100);  // RowsPerStrip = 100
-  
+
   // External BitsPerSample array (3 values for RGB)
   uint32_t bits_per_sample_offset = 200;
-  AddEntry(258, 3, 3, bits_per_sample_offset);  // BitsPerSample - external array
-  
+  AddEntry(258, 3, 3,
+           bits_per_sample_offset);  // BitsPerSample - external array
+
   // External SampleFormat array (3 values for RGB)
   uint32_t sample_format_offset = 212;
   AddEntry(339, 3, 3, sample_format_offset);  // SampleFormat - external array
-  
+
   // Add a StripOffsets and StripByteCounts entry to make this a valid TIFF
-  AddEntry(273, 4, 1, 1000);  // StripOffsets = 1000
-  AddEntry(279, 4, 1, 30000); // StripByteCounts = 30000
-  
+  AddEntry(273, 4, 1, 1000);   // StripOffsets = 1000
+  AddEntry(279, 4, 1, 30000);  // StripByteCounts = 30000
+
   // No more IFDs
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // Pad to BitsPerSample external array location
   while (tiff_data.size() < bits_per_sample_offset) {
     tiff_data.push_back('X');
   }
-  
+
   // Write BitsPerSample external array - 3 uint16_t values for RGB
   uint16_t bits_values[3] = {8, 8, 8};  // 8 bits per channel
   for (uint16_t val : bits_values) {
     tiff_data.push_back(val & 0xFF);
     tiff_data.push_back((val >> 8) & 0xFF);
   }
-  
+
   // Make sure we're at the sample_format_offset
   while (tiff_data.size() < sample_format_offset) {
     tiff_data.push_back('X');
   }
-  
+
   // Write SampleFormat external array - 3 uint16_t values for RGB
   uint16_t sample_format_values[3] = {1, 1, 1};  // 1 = unsigned integer
   for (uint16_t val : sample_format_values) {
     tiff_data.push_back(val & 0xFF);
     tiff_data.push_back((val >> 8) & 0xFF);
   }
-  
+
   // Pad the file to ensure it's large enough
   while (tiff_data.size() < 2048) {
     tiff_data.push_back('X');
   }
 
-  ASSERT_THAT(
-      tensorstore::kvstore::Write(memory, "uint16_arrays.tiff", absl::Cord(tiff_data))
-          .result(),
-      ::tensorstore::IsOk());
+  ASSERT_THAT(tensorstore::kvstore::Write(memory, "uint16_arrays.tiff",
+                                          absl::Cord(tiff_data))
+                  .result(),
+              ::tensorstore::IsOk());
 
   auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
-    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+    return std::make_unique<TiffDirectoryCache>(memory.driver,
+                                                InlineExecutor{});
   });
 
   auto entry = GetCacheEntry(cache, "uint16_arrays.tiff");
@@ -931,22 +1022,22 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_Uint16Arrays) {
   TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(*entry);
   auto* data = lock.data();
   ASSERT_THAT(data, ::testing::NotNull());
-  
+
   // Check that the uint16_t external arrays were loaded properly
   const auto& img_dir = data->image_directories[0];
-  
+
   // Check SamplesPerPixel
   EXPECT_EQ(img_dir.samples_per_pixel, 3);
-  
+
   // Check RowsPerStrip
   EXPECT_EQ(img_dir.rows_per_strip, 100);
-  
+
   // Check BitsPerSample array
   ASSERT_EQ(img_dir.bits_per_sample.size(), 3);
   for (int i = 0; i < 3; i++) {
     EXPECT_EQ(img_dir.bits_per_sample[i], bits_values[i]);
   }
-  
+
   // Check SampleFormat array
   ASSERT_EQ(img_dir.sample_format.size(), 3);
   for (int i = 0; i < 3; i++) {
@@ -966,18 +1057,23 @@ TEST(TiffDirectoryCacheTest, ComprehensiveTiffTagsTest) {
 
   // Create a TIFF file with all supported tags
   std::string tiff_data;
-  
+
   // TIFF header (8 bytes)
-  tiff_data += "II";                           // Little endian
-  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
-  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data += "II";  // Little endian
+  tiff_data.push_back(42);
+  tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8);
+  tiff_data.push_back(0);  // IFD offset (8)
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // IFD with 11 entries (all standard tags we support)
-  tiff_data.push_back(11); tiff_data.push_back(0);  // 11 entries
-  
+  tiff_data.push_back(11);
+  tiff_data.push_back(0);  // 11 entries
+
   // Helper to add an IFD entry
-  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count,
+                               uint32_t value) {
     tiff_data.push_back(tag & 0xFF);
     tiff_data.push_back((tag >> 8) & 0xFF);
     tiff_data.push_back(type & 0xFF);
@@ -991,36 +1087,39 @@ TEST(TiffDirectoryCacheTest, ComprehensiveTiffTagsTest) {
     tiff_data.push_back((value >> 16) & 0xFF);
     tiff_data.push_back((value >> 24) & 0xFF);
   };
-  
+
   // Add all standard tags with their test values
-  AddEntry(256, 3, 1, 1024);         // ImageWidth = 1024
-  AddEntry(257, 3, 1, 768);          // ImageLength = 768
-  AddEntry(258, 3, 1, 16);           // BitsPerSample = 16 (single value, inline)
-  AddEntry(259, 3, 1, 1);            // Compression = 1 (none)
-  AddEntry(262, 3, 1, 2);            // PhotometricInterpretation = 2 (RGB)
-  AddEntry(277, 3, 1, 1);            // SamplesPerPixel = 1
-  AddEntry(278, 3, 1, 128);          // RowsPerStrip = 128
-  AddEntry(273, 4, 1, 1000);         // StripOffsets = 1000
-  AddEntry(279, 4, 1, 65536);        // StripByteCounts = 65536
-  AddEntry(284, 3, 1, 1);            // PlanarConfiguration = 1 (chunky)
-  AddEntry(339, 3, 1, 1);            // SampleFormat = 1 (unsigned)
-  
+  AddEntry(256, 3, 1, 1024);   // ImageWidth = 1024
+  AddEntry(257, 3, 1, 768);    // ImageLength = 768
+  AddEntry(258, 3, 1, 16);     // BitsPerSample = 16 (single value, inline)
+  AddEntry(259, 3, 1, 1);      // Compression = 1 (none)
+  AddEntry(262, 3, 1, 2);      // PhotometricInterpretation = 2 (RGB)
+  AddEntry(277, 3, 1, 1);      // SamplesPerPixel = 1
+  AddEntry(278, 3, 1, 128);    // RowsPerStrip = 128
+  AddEntry(273, 4, 1, 1000);   // StripOffsets = 1000
+  AddEntry(279, 4, 1, 65536);  // StripByteCounts = 65536
+  AddEntry(284, 3, 1, 1);      // PlanarConfiguration = 1 (chunky)
+  AddEntry(339, 3, 1, 1);      // SampleFormat = 1 (unsigned)
+
   // No more IFDs
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // Pad the file to ensure it's large enough
   while (tiff_data.size() < 2048) {
     tiff_data.push_back('X');
   }
 
-  ASSERT_THAT(
-      tensorstore::kvstore::Write(memory, "comprehensive_tags.tiff", absl::Cord(tiff_data))
-          .result(),
-      ::tensorstore::IsOk());
+  ASSERT_THAT(tensorstore::kvstore::Write(memory, "comprehensive_tags.tiff",
+                                          absl::Cord(tiff_data))
+                  .result(),
+              ::tensorstore::IsOk());
 
   auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
-    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+    return std::make_unique<TiffDirectoryCache>(memory.driver,
+                                                InlineExecutor{});
   });
 
   auto entry = GetCacheEntry(cache, "comprehensive_tags.tiff");
@@ -1034,7 +1133,7 @@ TEST(TiffDirectoryCacheTest, ComprehensiveTiffTagsTest) {
   TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(*entry);
   auto* data = lock.data();
   ASSERT_THAT(data, ::testing::NotNull());
-  
+
   // Verify all tags were parsed correctly
   const auto& img_dir = data->image_directories[0];
   EXPECT_EQ(img_dir.width, 1024);
@@ -1066,18 +1165,23 @@ TEST(TiffDirectoryCacheTest, TiledTiffWithAllTags) {
 
   // Create a tiled TIFF file with all supported tags
   std::string tiff_data;
-  
+
   // TIFF header (8 bytes)
-  tiff_data += "II";                           // Little endian
-  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
-  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data += "II";  // Little endian
+  tiff_data.push_back(42);
+  tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8);
+  tiff_data.push_back(0);  // IFD offset (8)
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // IFD with 12 entries (all standard tags we support for tiled TIFF)
-  tiff_data.push_back(12); tiff_data.push_back(0);  // 12 entries
-  
+  tiff_data.push_back(12);
+  tiff_data.push_back(0);  // 12 entries
+
   // Helper to add an IFD entry
-  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count,
+                               uint32_t value) {
     tiff_data.push_back(tag & 0xFF);
     tiff_data.push_back((tag >> 8) & 0xFF);
     tiff_data.push_back(type & 0xFF);
@@ -1091,39 +1195,42 @@ TEST(TiffDirectoryCacheTest, TiledTiffWithAllTags) {
     tiff_data.push_back((value >> 16) & 0xFF);
     tiff_data.push_back((value >> 24) & 0xFF);
   };
-  
+
   // Add all standard tags with their test values for a tiled TIFF
-  AddEntry(256, 3, 1, 2048);         // ImageWidth = 2048
-  AddEntry(257, 3, 1, 2048);         // ImageLength = 2048
-  AddEntry(258, 3, 1, 32);           // BitsPerSample = 32
-  AddEntry(259, 3, 1, 8);            // Compression = 8 (Deflate)
-  AddEntry(262, 3, 1, 1);            // PhotometricInterpretation = 1 (BlackIsZero)
-  AddEntry(277, 3, 1, 1);            // SamplesPerPixel = 1
-  AddEntry(284, 3, 1, 1);            // PlanarConfiguration = 1 (chunky)
-  AddEntry(339, 3, 1, 3);            // SampleFormat = 3 (IEEE float)
-  
+  AddEntry(256, 3, 1, 2048);  // ImageWidth = 2048
+  AddEntry(257, 3, 1, 2048);  // ImageLength = 2048
+  AddEntry(258, 3, 1, 32);    // BitsPerSample = 32
+  AddEntry(259, 3, 1, 8);     // Compression = 8 (Deflate)
+  AddEntry(262, 3, 1, 1);     // PhotometricInterpretation = 1 (BlackIsZero)
+  AddEntry(277, 3, 1, 1);     // SamplesPerPixel = 1
+  AddEntry(284, 3, 1, 1);     // PlanarConfiguration = 1 (chunky)
+  AddEntry(339, 3, 1, 3);     // SampleFormat = 3 (IEEE float)
+
   // Tile-specific tags
-  AddEntry(322, 3, 1, 256);          // TileWidth = 256
-  AddEntry(323, 3, 1, 256);          // TileLength = 256
-  AddEntry(324, 4, 1, 1000);         // TileOffsets = 1000
-  AddEntry(325, 4, 1, 10000);        // TileByteCounts = 10000
-  
+  AddEntry(322, 3, 1, 256);    // TileWidth = 256
+  AddEntry(323, 3, 1, 256);    // TileLength = 256
+  AddEntry(324, 4, 1, 1000);   // TileOffsets = 1000
+  AddEntry(325, 4, 1, 10000);  // TileByteCounts = 10000
+
   // No more IFDs
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  tiff_data.push_back(0); tiff_data.push_back(0);
-  
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+  tiff_data.push_back(0);
+
   // Pad the file to ensure it's large enough
   while (tiff_data.size() < 2048) {
     tiff_data.push_back('X');
   }
 
-  ASSERT_THAT(
-      tensorstore::kvstore::Write(memory, "tiled_tiff_all_tags.tiff", absl::Cord(tiff_data))
-          .result(),
-      ::tensorstore::IsOk());
+  ASSERT_THAT(tensorstore::kvstore::Write(memory, "tiled_tiff_all_tags.tiff",
+                                          absl::Cord(tiff_data))
+                  .result(),
+              ::tensorstore::IsOk());
 
   auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
-    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+    return std::make_unique<TiffDirectoryCache>(memory.driver,
+                                                InlineExecutor{});
   });
 
   auto entry = GetCacheEntry(cache, "tiled_tiff_all_tags.tiff");
@@ -1137,10 +1244,10 @@ TEST(TiffDirectoryCacheTest, TiledTiffWithAllTags) {
   TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(*entry);
   auto* data = lock.data();
   ASSERT_THAT(data, ::testing::NotNull());
-  
+
   // Verify all tags were parsed correctly
   const auto& img_dir = data->image_directories[0];
-  
+
   // Basic image properties
   EXPECT_EQ(img_dir.width, 2048);
   EXPECT_EQ(img_dir.height, 2048);
@@ -1152,7 +1259,7 @@ TEST(TiffDirectoryCacheTest, TiledTiffWithAllTags) {
   EXPECT_EQ(img_dir.planar_config, 1);  // Chunky
   ASSERT_EQ(img_dir.sample_format.size(), 1);
   EXPECT_EQ(img_dir.sample_format[0], 3);  // IEEE float
-  
+
   // Tile-specific properties
   EXPECT_EQ(img_dir.tile_width, 256);
   EXPECT_EQ(img_dir.tile_height, 256);

--- a/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
@@ -823,4 +823,343 @@ TEST(TiffDirectoryCacheMultiIfdTest, ExternalArraysMultiIfdTest) {
   EXPECT_EQ(data->image_directories[1].tile_bytecounts.size(), 4);
 }
 
+TEST(TiffDirectoryCacheTest, ExternalArrays_Uint16Arrays) {
+  auto context = Context::Default();
+  auto pool = CachePool::Make(CachePool::Limits{});
+
+  // Create an in-memory kvstore with test data
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      tensorstore::KvStore memory,
+      tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
+
+  // Create a TIFF file with uint16_t external arrays (BitsPerSample and SampleFormat)
+  std::string tiff_data;
+  
+  // TIFF header (8 bytes)
+  tiff_data += "II";                           // Little endian
+  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // IFD with 8 entries
+  tiff_data.push_back(8); tiff_data.push_back(0);  // 8 entries
+  
+  // Helper to add an IFD entry
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+    tiff_data.push_back(tag & 0xFF);
+    tiff_data.push_back((tag >> 8) & 0xFF);
+    tiff_data.push_back(type & 0xFF);
+    tiff_data.push_back((type >> 8) & 0xFF);
+    tiff_data.push_back(count & 0xFF);
+    tiff_data.push_back((count >> 8) & 0xFF);
+    tiff_data.push_back((count >> 16) & 0xFF);
+    tiff_data.push_back((count >> 24) & 0xFF);
+    tiff_data.push_back(value & 0xFF);
+    tiff_data.push_back((value >> 8) & 0xFF);
+    tiff_data.push_back((value >> 16) & 0xFF);
+    tiff_data.push_back((value >> 24) & 0xFF);
+  };
+  
+  // Basic image info
+  AddEntry(256, 3, 1, 800);  // ImageWidth = 800
+  AddEntry(257, 3, 1, 600);  // ImageLength = 600
+  AddEntry(277, 3, 1, 3);    // SamplesPerPixel = 3 (RGB)
+  AddEntry(278, 3, 1, 100);  // RowsPerStrip = 100
+  
+  // External BitsPerSample array (3 values for RGB)
+  uint32_t bits_per_sample_offset = 200;
+  AddEntry(258, 3, 3, bits_per_sample_offset);  // BitsPerSample - external array
+  
+  // External SampleFormat array (3 values for RGB)
+  uint32_t sample_format_offset = 212;
+  AddEntry(339, 3, 3, sample_format_offset);  // SampleFormat - external array
+  
+  // Add a StripOffsets and StripByteCounts entry to make this a valid TIFF
+  AddEntry(273, 4, 1, 1000);  // StripOffsets = 1000
+  AddEntry(279, 4, 1, 30000); // StripByteCounts = 30000
+  
+  // No more IFDs
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // Pad to BitsPerSample external array location
+  while (tiff_data.size() < bits_per_sample_offset) {
+    tiff_data.push_back('X');
+  }
+  
+  // Write BitsPerSample external array - 3 uint16_t values for RGB
+  uint16_t bits_values[3] = {8, 8, 8};  // 8 bits per channel
+  for (uint16_t val : bits_values) {
+    tiff_data.push_back(val & 0xFF);
+    tiff_data.push_back((val >> 8) & 0xFF);
+  }
+  
+  // Make sure we're at the sample_format_offset
+  while (tiff_data.size() < sample_format_offset) {
+    tiff_data.push_back('X');
+  }
+  
+  // Write SampleFormat external array - 3 uint16_t values for RGB
+  uint16_t sample_format_values[3] = {1, 1, 1};  // 1 = unsigned integer
+  for (uint16_t val : sample_format_values) {
+    tiff_data.push_back(val & 0xFF);
+    tiff_data.push_back((val >> 8) & 0xFF);
+  }
+  
+  // Pad the file to ensure it's large enough
+  while (tiff_data.size() < 2048) {
+    tiff_data.push_back('X');
+  }
+
+  ASSERT_THAT(
+      tensorstore::kvstore::Write(memory, "uint16_arrays.tiff", absl::Cord(tiff_data))
+          .result(),
+      ::tensorstore::IsOk());
+
+  auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
+    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+  });
+
+  auto entry = GetCacheEntry(cache, "uint16_arrays.tiff");
+
+  // Request to read the TIFF with external uint16_t arrays
+  tensorstore::internal::AsyncCache::AsyncCacheReadRequest request;
+  request.staleness_bound = absl::InfinitePast();
+
+  ASSERT_THAT(entry->Read(request).result(), ::tensorstore::IsOk());
+
+  TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(*entry);
+  auto* data = lock.data();
+  ASSERT_THAT(data, ::testing::NotNull());
+  
+  // Check that the uint16_t external arrays were loaded properly
+  const auto& img_dir = data->image_directories[0];
+  
+  // Check SamplesPerPixel
+  EXPECT_EQ(img_dir.samples_per_pixel, 3);
+  
+  // Check RowsPerStrip
+  EXPECT_EQ(img_dir.rows_per_strip, 100);
+  
+  // Check BitsPerSample array
+  ASSERT_EQ(img_dir.bits_per_sample.size(), 3);
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(img_dir.bits_per_sample[i], bits_values[i]);
+  }
+  
+  // Check SampleFormat array
+  ASSERT_EQ(img_dir.sample_format.size(), 3);
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(img_dir.sample_format[i], sample_format_values[i]);
+  }
+}
+
+// Add a comprehensive test that checks all supported TIFF tags
+TEST(TiffDirectoryCacheTest, ComprehensiveTiffTagsTest) {
+  auto context = Context::Default();
+  auto pool = CachePool::Make(CachePool::Limits{});
+
+  // Create an in-memory kvstore with test data
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      tensorstore::KvStore memory,
+      tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
+
+  // Create a TIFF file with all supported tags
+  std::string tiff_data;
+  
+  // TIFF header (8 bytes)
+  tiff_data += "II";                           // Little endian
+  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // IFD with 11 entries (all standard tags we support)
+  tiff_data.push_back(11); tiff_data.push_back(0);  // 11 entries
+  
+  // Helper to add an IFD entry
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+    tiff_data.push_back(tag & 0xFF);
+    tiff_data.push_back((tag >> 8) & 0xFF);
+    tiff_data.push_back(type & 0xFF);
+    tiff_data.push_back((type >> 8) & 0xFF);
+    tiff_data.push_back(count & 0xFF);
+    tiff_data.push_back((count >> 8) & 0xFF);
+    tiff_data.push_back((count >> 16) & 0xFF);
+    tiff_data.push_back((count >> 24) & 0xFF);
+    tiff_data.push_back(value & 0xFF);
+    tiff_data.push_back((value >> 8) & 0xFF);
+    tiff_data.push_back((value >> 16) & 0xFF);
+    tiff_data.push_back((value >> 24) & 0xFF);
+  };
+  
+  // Add all standard tags with their test values
+  AddEntry(256, 3, 1, 1024);         // ImageWidth = 1024
+  AddEntry(257, 3, 1, 768);          // ImageLength = 768
+  AddEntry(258, 3, 1, 16);           // BitsPerSample = 16 (single value, inline)
+  AddEntry(259, 3, 1, 1);            // Compression = 1 (none)
+  AddEntry(262, 3, 1, 2);            // PhotometricInterpretation = 2 (RGB)
+  AddEntry(277, 3, 1, 1);            // SamplesPerPixel = 1
+  AddEntry(278, 3, 1, 128);          // RowsPerStrip = 128
+  AddEntry(273, 4, 1, 1000);         // StripOffsets = 1000
+  AddEntry(279, 4, 1, 65536);        // StripByteCounts = 65536
+  AddEntry(284, 3, 1, 1);            // PlanarConfiguration = 1 (chunky)
+  AddEntry(339, 3, 1, 1);            // SampleFormat = 1 (unsigned)
+  
+  // No more IFDs
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // Pad the file to ensure it's large enough
+  while (tiff_data.size() < 2048) {
+    tiff_data.push_back('X');
+  }
+
+  ASSERT_THAT(
+      tensorstore::kvstore::Write(memory, "comprehensive_tags.tiff", absl::Cord(tiff_data))
+          .result(),
+      ::tensorstore::IsOk());
+
+  auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
+    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+  });
+
+  auto entry = GetCacheEntry(cache, "comprehensive_tags.tiff");
+
+  // Read the TIFF
+  tensorstore::internal::AsyncCache::AsyncCacheReadRequest request;
+  request.staleness_bound = absl::InfinitePast();
+
+  ASSERT_THAT(entry->Read(request).result(), ::tensorstore::IsOk());
+
+  TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(*entry);
+  auto* data = lock.data();
+  ASSERT_THAT(data, ::testing::NotNull());
+  
+  // Verify all tags were parsed correctly
+  const auto& img_dir = data->image_directories[0];
+  EXPECT_EQ(img_dir.width, 1024);
+  EXPECT_EQ(img_dir.height, 768);
+  ASSERT_EQ(img_dir.bits_per_sample.size(), 1);
+  EXPECT_EQ(img_dir.bits_per_sample[0], 16);
+  EXPECT_EQ(img_dir.compression, 1);  // None
+  EXPECT_EQ(img_dir.photometric, 2);  // RGB
+  EXPECT_EQ(img_dir.samples_per_pixel, 1);
+  EXPECT_EQ(img_dir.rows_per_strip, 128);
+  ASSERT_EQ(img_dir.strip_offsets.size(), 1);
+  EXPECT_EQ(img_dir.strip_offsets[0], 1000);
+  ASSERT_EQ(img_dir.strip_bytecounts.size(), 1);
+  EXPECT_EQ(img_dir.strip_bytecounts[0], 65536);
+  EXPECT_EQ(img_dir.planar_config, 1);  // Chunky
+  ASSERT_EQ(img_dir.sample_format.size(), 1);
+  EXPECT_EQ(img_dir.sample_format[0], 1);  // Unsigned integer
+}
+
+// Add a test for a tiled TIFF with all supported tags
+TEST(TiffDirectoryCacheTest, TiledTiffWithAllTags) {
+  auto context = Context::Default();
+  auto pool = CachePool::Make(CachePool::Limits{});
+
+  // Create an in-memory kvstore with test data
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      tensorstore::KvStore memory,
+      tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
+
+  // Create a tiled TIFF file with all supported tags
+  std::string tiff_data;
+  
+  // TIFF header (8 bytes)
+  tiff_data += "II";                           // Little endian
+  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // IFD with 12 entries (all standard tags we support for tiled TIFF)
+  tiff_data.push_back(12); tiff_data.push_back(0);  // 12 entries
+  
+  // Helper to add an IFD entry
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+    tiff_data.push_back(tag & 0xFF);
+    tiff_data.push_back((tag >> 8) & 0xFF);
+    tiff_data.push_back(type & 0xFF);
+    tiff_data.push_back((type >> 8) & 0xFF);
+    tiff_data.push_back(count & 0xFF);
+    tiff_data.push_back((count >> 8) & 0xFF);
+    tiff_data.push_back((count >> 16) & 0xFF);
+    tiff_data.push_back((count >> 24) & 0xFF);
+    tiff_data.push_back(value & 0xFF);
+    tiff_data.push_back((value >> 8) & 0xFF);
+    tiff_data.push_back((value >> 16) & 0xFF);
+    tiff_data.push_back((value >> 24) & 0xFF);
+  };
+  
+  // Add all standard tags with their test values for a tiled TIFF
+  AddEntry(256, 3, 1, 2048);         // ImageWidth = 2048
+  AddEntry(257, 3, 1, 2048);         // ImageLength = 2048
+  AddEntry(258, 3, 1, 32);           // BitsPerSample = 32
+  AddEntry(259, 3, 1, 8);            // Compression = 8 (Deflate)
+  AddEntry(262, 3, 1, 1);            // PhotometricInterpretation = 1 (BlackIsZero)
+  AddEntry(277, 3, 1, 1);            // SamplesPerPixel = 1
+  AddEntry(284, 3, 1, 1);            // PlanarConfiguration = 1 (chunky)
+  AddEntry(339, 3, 1, 3);            // SampleFormat = 3 (IEEE float)
+  
+  // Tile-specific tags
+  AddEntry(322, 3, 1, 256);          // TileWidth = 256
+  AddEntry(323, 3, 1, 256);          // TileLength = 256
+  AddEntry(324, 4, 1, 1000);         // TileOffsets = 1000
+  AddEntry(325, 4, 1, 10000);        // TileByteCounts = 10000
+  
+  // No more IFDs
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // Pad the file to ensure it's large enough
+  while (tiff_data.size() < 2048) {
+    tiff_data.push_back('X');
+  }
+
+  ASSERT_THAT(
+      tensorstore::kvstore::Write(memory, "tiled_tiff_all_tags.tiff", absl::Cord(tiff_data))
+          .result(),
+      ::tensorstore::IsOk());
+
+  auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
+    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+  });
+
+  auto entry = GetCacheEntry(cache, "tiled_tiff_all_tags.tiff");
+
+  // Read the TIFF
+  tensorstore::internal::AsyncCache::AsyncCacheReadRequest request;
+  request.staleness_bound = absl::InfinitePast();
+
+  ASSERT_THAT(entry->Read(request).result(), ::tensorstore::IsOk());
+
+  TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(*entry);
+  auto* data = lock.data();
+  ASSERT_THAT(data, ::testing::NotNull());
+  
+  // Verify all tags were parsed correctly
+  const auto& img_dir = data->image_directories[0];
+  
+  // Basic image properties
+  EXPECT_EQ(img_dir.width, 2048);
+  EXPECT_EQ(img_dir.height, 2048);
+  ASSERT_EQ(img_dir.bits_per_sample.size(), 1);
+  EXPECT_EQ(img_dir.bits_per_sample[0], 32);
+  EXPECT_EQ(img_dir.compression, 8);  // Deflate
+  EXPECT_EQ(img_dir.photometric, 1);  // BlackIsZero
+  EXPECT_EQ(img_dir.samples_per_pixel, 1);
+  EXPECT_EQ(img_dir.planar_config, 1);  // Chunky
+  ASSERT_EQ(img_dir.sample_format.size(), 1);
+  EXPECT_EQ(img_dir.sample_format[0], 3);  // IEEE float
+  
+  // Tile-specific properties
+  EXPECT_EQ(img_dir.tile_width, 256);
+  EXPECT_EQ(img_dir.tile_height, 256);
+  ASSERT_EQ(img_dir.tile_offsets.size(), 1);
+  EXPECT_EQ(img_dir.tile_offsets[0], 1000);
+  ASSERT_EQ(img_dir.tile_bytecounts.size(), 1);
+  EXPECT_EQ(img_dir.tile_bytecounts[0], 10000);
+}
+
 }  // namespace

--- a/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
@@ -1,6 +1,6 @@
 // Copyright 2025 The TensorStore Authors
 //
-// Licensed under the Apache License, Version .0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -330,7 +330,6 @@ TEST(TiffDirectoryCacheTest, ExternalArrays_BadPointer) {
   auto read_result = entry->Read(request).result();
   EXPECT_THAT(read_result.status(), ::testing::Not(::tensorstore::IsOk()));
 
-  std::cout << "Status: " << read_result.status() << std::endl;
   // Should fail with OutOfRange, InvalidArgument, or DataLoss error
   EXPECT_TRUE(absl::IsOutOfRange(read_result.status()) ||
               absl::IsDataLoss(read_result.status()) ||

--- a/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
@@ -38,10 +38,6 @@ using ::tensorstore::internal::CachePool;
 using ::tensorstore::internal::GetCache;
 using ::tensorstore::internal_tiff_kvstore::TiffDirectoryCache;
 
-// Creates test data of specified size filled with 'X' pattern
-absl::Cord CreateTestData(size_t size) {
-  return absl::Cord(std::string(size, 'X'));
-}
 
 TEST(TiffDirectoryCacheTest, ReadSlice) {
   auto context = Context::Default();
@@ -52,8 +48,55 @@ TEST(TiffDirectoryCacheTest, ReadSlice) {
       tensorstore::KvStore memory,
       tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
 
+  // Create a small TIFF file with a valid header and IFD
+  std::string tiff_data;
+  
+  // TIFF header (8 bytes)
+  tiff_data += "II";                           // Little endian
+  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // IFD with 5 entries
+  tiff_data.push_back(6); tiff_data.push_back(0);  // 5 entries
+  
+  // Helper to add an IFD entry
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+    tiff_data.push_back(tag & 0xFF);
+    tiff_data.push_back((tag >> 8) & 0xFF);
+    tiff_data.push_back(type & 0xFF);
+    tiff_data.push_back((type >> 8) & 0xFF);
+    tiff_data.push_back(count & 0xFF);
+    tiff_data.push_back((count >> 8) & 0xFF);
+    tiff_data.push_back((count >> 16) & 0xFF);
+    tiff_data.push_back((count >> 24) & 0xFF);
+    tiff_data.push_back(value & 0xFF);
+    tiff_data.push_back((value >> 8) & 0xFF);
+    tiff_data.push_back((value >> 16) & 0xFF);
+    tiff_data.push_back((value >> 24) & 0xFF);
+  };
+  
+  // Width and height
+  AddEntry(256, 3, 1, 800);  // ImageWidth = 800
+  AddEntry(257, 3, 1, 600);  // ImageLength = 600
+  
+  // Tile info
+  AddEntry(322, 3, 1, 256);  // TileWidth = 256
+  AddEntry(323, 3, 1, 256);  // TileLength = 256
+  AddEntry(324, 4, 1, 128);  // TileOffsets = 128
+  AddEntry(325, 4, 1, 256);  // TileByteCounts = 256
+  
+  // No more IFDs
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // Pad to 2048 bytes (more than kInitialReadBytes)
+  while (tiff_data.size() < 2048) {
+    tiff_data.push_back('X');
+  }
+
   ASSERT_THAT(
-      tensorstore::kvstore::Write(memory, "test.tiff", CreateTestData(2048))
+      tensorstore::kvstore::Write(memory, "test.tiff", absl::Cord(tiff_data))
           .result(),
       ::tensorstore::IsOk());
 
@@ -75,6 +118,15 @@ TEST(TiffDirectoryCacheTest, ReadSlice) {
     ASSERT_THAT(data, ::testing::NotNull());
     EXPECT_EQ(data->raw_data.size(), 1024);
     EXPECT_FALSE(data->full_read);
+    
+    // Check parsed IFD entries
+    EXPECT_EQ(data->ifd_entries.size(), 6);
+    
+    // Check parsed image directory
+    EXPECT_EQ(data->image_directory.width, 800);
+    EXPECT_EQ(data->image_directory.height, 600);
+    EXPECT_EQ(data->image_directory.tile_width, 256);
+    EXPECT_EQ(data->image_directory.tile_height, 256);
   }
 }
 
@@ -87,8 +139,52 @@ TEST(TiffDirectoryCacheTest, ReadFull) {
       tensorstore::KvStore memory,
       tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
 
+  // Create a small TIFF file with a valid header and IFD - similar to above but smaller
+  std::string tiff_data;
+  
+  // TIFF header (8 bytes)
+  tiff_data += "II";                              // Little endian
+  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // IFD with 5 entries
+  tiff_data.push_back(5); tiff_data.push_back(0);  // 5 entries
+  
+  // Helper to add an IFD entry
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+    tiff_data.push_back(tag & 0xFF);
+    tiff_data.push_back((tag >> 8) & 0xFF);
+    tiff_data.push_back(type & 0xFF);
+    tiff_data.push_back((type >> 8) & 0xFF);
+    tiff_data.push_back(count & 0xFF);
+    tiff_data.push_back((count >> 8) & 0xFF);
+    tiff_data.push_back((count >> 16) & 0xFF);
+    tiff_data.push_back((count >> 24) & 0xFF);
+    tiff_data.push_back(value & 0xFF);
+    tiff_data.push_back((value >> 8) & 0xFF);
+    tiff_data.push_back((value >> 16) & 0xFF);
+    tiff_data.push_back((value >> 24) & 0xFF);
+  };
+  
+  // Add strip-based entries 
+  AddEntry(256, 3, 1, 400);  // ImageWidth = 400
+  AddEntry(257, 3, 1, 300);  // ImageLength = 300
+  AddEntry(278, 3, 1, 100);  // RowsPerStrip = 100
+  AddEntry(273, 4, 1, 128);  // StripOffsets = 128
+  AddEntry(279, 4, 1, 200);  // StripByteCounts = 200
+  
+  // No more IFDs
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // Pad to fill data
+  while (tiff_data.size() < 512) {
+    tiff_data.push_back('X');
+  }
+
   ASSERT_THAT(
-      tensorstore::kvstore::Write(memory, "test.tiff", CreateTestData(512))
+      tensorstore::kvstore::Write(memory, "test.tiff", absl::Cord(tiff_data))
           .result(),
       ::tensorstore::IsOk());
 
@@ -110,7 +206,69 @@ TEST(TiffDirectoryCacheTest, ReadFull) {
     ASSERT_THAT(data, ::testing::NotNull());
     EXPECT_EQ(data->raw_data.size(), 512);
     EXPECT_TRUE(data->full_read);
+    
+    // Check parsed IFD entries
+    EXPECT_EQ(data->ifd_entries.size(), 5);
+    
+    // Check parsed image directory
+    EXPECT_EQ(data->image_directory.width, 400);
+    EXPECT_EQ(data->image_directory.height, 300);
+    EXPECT_EQ(data->image_directory.rows_per_strip, 100);
+    EXPECT_EQ(data->image_directory.strip_offsets.size(), 1);
+    EXPECT_EQ(data->image_directory.strip_offsets[0], 128);
+    EXPECT_EQ(data->image_directory.strip_bytecounts.size(), 1);
+    EXPECT_EQ(data->image_directory.strip_bytecounts[0], 200);
   }
+}
+
+TEST(TiffDirectoryCacheTest, BadIfdFailsParse) {
+  auto context = Context::Default();
+  auto pool = CachePool::Make(CachePool::Limits{});
+
+  // Create an in-memory kvstore with test data
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      tensorstore::KvStore memory,
+      tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
+
+  // Create a corrupt TIFF file with invalid IFD
+  std::string corrupt_tiff;
+  
+  // Valid TIFF header
+  corrupt_tiff += "II";                              // Little endian
+  corrupt_tiff.push_back(42); corrupt_tiff.push_back(0);  // Magic number
+  corrupt_tiff.push_back(8); corrupt_tiff.push_back(0);   // IFD offset (8)
+  corrupt_tiff.push_back(0); corrupt_tiff.push_back(0);
+  
+  // Corrupt IFD - claim 10 entries but only provide data for 1
+  corrupt_tiff.push_back(10); corrupt_tiff.push_back(0);  // 10 entries (too many)
+  
+  // Only one entry (not enough data for 10)
+  corrupt_tiff.push_back(1); corrupt_tiff.push_back(1);   // tag
+  corrupt_tiff.push_back(1); corrupt_tiff.push_back(0);   // type
+  corrupt_tiff.push_back(1); corrupt_tiff.push_back(0);   // count
+  corrupt_tiff.push_back(0); corrupt_tiff.push_back(0);
+  corrupt_tiff.push_back(0); corrupt_tiff.push_back(0);   // value
+  corrupt_tiff.push_back(0); corrupt_tiff.push_back(0);
+
+  ASSERT_THAT(
+      tensorstore::kvstore::Write(memory, "corrupt.tiff", absl::Cord(corrupt_tiff))
+          .result(),
+      ::tensorstore::IsOk());
+
+  auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
+    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+  });
+
+  auto entry = GetCacheEntry(cache, "corrupt.tiff");
+
+  tensorstore::internal::AsyncCache::AsyncCacheReadRequest request;
+  request.staleness_bound = absl::InfinitePast();
+
+  // Reading should fail due to corrupt IFD
+  auto read_result = entry->Read(request).result();
+  EXPECT_THAT(read_result.status(), ::testing::Not(::tensorstore::IsOk()));
+  EXPECT_TRUE(absl::IsDataLoss(read_result.status()) || 
+              absl::IsInvalidArgument(read_result.status()));
 }
 
 }  // namespace

--- a/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
@@ -1,6 +1,6 @@
 // Copyright 2025 The TensorStore Authors
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Licensed under the Apache License, Version .0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -269,6 +269,206 @@ TEST(TiffDirectoryCacheTest, BadIfdFailsParse) {
   EXPECT_THAT(read_result.status(), ::testing::Not(::tensorstore::IsOk()));
   EXPECT_TRUE(absl::IsDataLoss(read_result.status()) || 
               absl::IsInvalidArgument(read_result.status()));
+}
+
+TEST(TiffDirectoryCacheTest, ExternalArrays_EagerLoad) {
+  auto context = Context::Default();
+  auto pool = CachePool::Make(CachePool::Limits{});
+
+  // Create an in-memory kvstore with test data
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      tensorstore::KvStore memory,
+      tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
+
+  // Create a TIFF file with external array references
+  std::string tiff_data;
+  
+  // TIFF header (8 bytes)
+  tiff_data += "II";                           // Little endian
+  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // IFD with 5 entries
+  tiff_data.push_back(5); tiff_data.push_back(0);  // 5 entries
+  
+  // Helper to add an IFD entry
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+    tiff_data.push_back(tag & 0xFF);
+    tiff_data.push_back((tag >> 8) & 0xFF);
+    tiff_data.push_back(type & 0xFF);
+    tiff_data.push_back((type >> 8) & 0xFF);
+    tiff_data.push_back(count & 0xFF);
+    tiff_data.push_back((count >> 8) & 0xFF);
+    tiff_data.push_back((count >> 16) & 0xFF);
+    tiff_data.push_back((count >> 24) & 0xFF);
+    tiff_data.push_back(value & 0xFF);
+    tiff_data.push_back((value >> 8) & 0xFF);
+    tiff_data.push_back((value >> 16) & 0xFF);
+    tiff_data.push_back((value >> 24) & 0xFF);
+  };
+  
+  // Basic image info
+  AddEntry(256, 3, 1, 800);  // ImageWidth = 800
+  AddEntry(257, 3, 1, 600);  // ImageLength = 600
+  AddEntry(278, 3, 1, 100);  // RowsPerStrip = 100
+  
+  // External strip offsets array (4 strips)
+  uint32_t strip_offsets_offset = 200; // Position of external array in file
+  AddEntry(273, 4, 4, strip_offsets_offset);  // StripOffsets - points to external array
+  
+  // External strip bytecounts array (4 strips)
+  uint32_t strip_bytecounts_offset = 216; // Position of external array in file
+  AddEntry(279, 4, 4, strip_bytecounts_offset);  // StripByteCounts - points to external array
+  
+  // No more IFDs
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // Pad to 200 bytes to reach strip_offsets_offset
+  while (tiff_data.size() < strip_offsets_offset) {
+    tiff_data.push_back('X');
+  }
+  
+  // Write the strip offsets external array (4 strips)
+  uint32_t strip_offsets[4] = {1000, 2000, 3000, 4000};
+  for (uint32_t offset : strip_offsets) {
+    tiff_data.push_back(offset & 0xFF);
+    tiff_data.push_back((offset >> 8) & 0xFF);
+    tiff_data.push_back((offset >> 16) & 0xFF);
+    tiff_data.push_back((offset >> 24) & 0xFF);
+  }
+  
+  // Write the strip bytecounts external array (4 strips)
+  uint32_t strip_bytecounts[4] = {500, 600, 700, 800};
+  for (uint32_t bytecount : strip_bytecounts) {
+    tiff_data.push_back(bytecount & 0xFF);
+    tiff_data.push_back((bytecount >> 8) & 0xFF);
+    tiff_data.push_back((bytecount >> 16) & 0xFF);
+    tiff_data.push_back((bytecount >> 24) & 0xFF);
+  }
+  
+  // Pad the file to ensure it's large enough
+  while (tiff_data.size() < 4096) {
+    tiff_data.push_back('X');
+  }
+
+  ASSERT_THAT(
+      tensorstore::kvstore::Write(memory, "external_arrays.tiff", absl::Cord(tiff_data))
+          .result(),
+      ::tensorstore::IsOk());
+
+  auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
+    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+  });
+
+  auto entry = GetCacheEntry(cache, "external_arrays.tiff");
+
+  // Request to read the TIFF with external arrays
+  {
+    tensorstore::internal::AsyncCache::AsyncCacheReadRequest request;
+    request.staleness_bound = absl::InfinitePast();
+
+    ASSERT_THAT(entry->Read(request).result(), ::tensorstore::IsOk());
+
+    TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(*entry);
+    auto* data = lock.data();
+    ASSERT_THAT(data, ::testing::NotNull());
+    
+    // Check that external arrays were loaded
+    EXPECT_EQ(data->image_directory.strip_offsets.size(), 4);
+    EXPECT_EQ(data->image_directory.strip_bytecounts.size(), 4);
+    
+    // Verify the external array values were loaded correctly
+    for (int i = 0; i < 4; i++) {
+      EXPECT_EQ(data->image_directory.strip_offsets[i], strip_offsets[i]);
+      EXPECT_EQ(data->image_directory.strip_bytecounts[i], strip_bytecounts[i]);
+    }
+  }
+}
+
+TEST(TiffDirectoryCacheTest, ExternalArrays_BadPointer) {
+  auto context = Context::Default();
+  auto pool = CachePool::Make(CachePool::Limits{});
+
+  // Create an in-memory kvstore with test data
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      tensorstore::KvStore memory,
+      tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
+
+  // Create a TIFF file with an invalid external array reference
+  std::string tiff_data;
+  
+  // TIFF header (8 bytes)
+  tiff_data += "II";                           // Little endian
+  tiff_data.push_back(42); tiff_data.push_back(0);  // Magic number
+  tiff_data.push_back(8); tiff_data.push_back(0);   // IFD offset (8)
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // IFD with 5 entries
+  tiff_data.push_back(5); tiff_data.push_back(0);  // 5 entries
+  
+  // Helper to add an IFD entry
+  auto AddEntry = [&tiff_data](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+    tiff_data.push_back(tag & 0xFF);
+    tiff_data.push_back((tag >> 8) & 0xFF);
+    tiff_data.push_back(type & 0xFF);
+    tiff_data.push_back((type >> 8) & 0xFF);
+    tiff_data.push_back(count & 0xFF);
+    tiff_data.push_back((count >> 8) & 0xFF);
+    tiff_data.push_back((count >> 16) & 0xFF);
+    tiff_data.push_back((count >> 24) & 0xFF);
+    tiff_data.push_back(value & 0xFF);
+    tiff_data.push_back((value >> 8) & 0xFF);
+    tiff_data.push_back((value >> 16) & 0xFF);
+    tiff_data.push_back((value >> 24) & 0xFF);
+  };
+  
+  // Basic image info
+  AddEntry(256, 3, 1, 800);  // ImageWidth = 800
+  AddEntry(257, 3, 1, 600);  // ImageLength = 600
+  AddEntry(278, 3, 1, 100);  // RowsPerStrip = 100
+  
+  // External strip offsets array with INVALID OFFSET - points beyond file end
+  uint32_t invalid_offset = 50000;  // Far beyond our file size
+  AddEntry(273, 4, 4, invalid_offset);  // StripOffsets - points to invalid location
+  
+  // Valid strip bytecounts
+  AddEntry(279, 4, 1, 500);  // StripByteCounts - inline value
+  
+  // No more IFDs
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  tiff_data.push_back(0); tiff_data.push_back(0);
+  
+  // Pad the file to a reasonable size, but less than invalid_offset
+  while (tiff_data.size() < 1000) {
+    tiff_data.push_back('X');
+  }
+
+  ASSERT_THAT(
+      tensorstore::kvstore::Write(memory, "bad_external_array.tiff", absl::Cord(tiff_data))
+          .result(),
+      ::tensorstore::IsOk());
+
+  auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
+    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+  });
+
+  auto entry = GetCacheEntry(cache, "bad_external_array.tiff");
+
+  // Reading should fail due to invalid external array pointer
+  tensorstore::internal::AsyncCache::AsyncCacheReadRequest request;
+  request.staleness_bound = absl::InfinitePast();
+
+  auto read_result = entry->Read(request).result();
+  EXPECT_THAT(read_result.status(), ::testing::Not(::tensorstore::IsOk()));
+  
+  std::cout << "Status: " << read_result.status() << std::endl;
+  // Should fail with OutOfRange, InvalidArgument, or DataLoss error
+  EXPECT_TRUE(absl::IsOutOfRange(read_result.status()) || 
+              absl::IsDataLoss(read_result.status()) ||
+              absl::IsInvalidArgument(read_result.status()) ||
+              absl::IsFailedPrecondition(read_result.status()));
 }
 
 }  // namespace

--- a/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
@@ -701,7 +701,6 @@ TEST(TiffDirectoryCacheMultiIfdTest, ReadLargeMultiPageTiff) {
   EXPECT_EQ(data->image_directories[1].width, 800);
 }
 
-// ...existing code...
 TEST(TiffDirectoryCacheMultiIfdTest, ExternalArraysMultiIfdTest) {
   auto context = Context::Default();
   auto pool = CachePool::Make(CachePool::Limits{});

--- a/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_dir_cache_test.cc
@@ -1,0 +1,116 @@
+// Copyright 2025 The TensorStore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tensorstore/kvstore/tiff/tiff_dir_cache.h"
+
+#include <memory>
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/strings/cord.h"
+#include "absl/time/time.h"
+#include "tensorstore/context.h"
+#include "tensorstore/internal/cache/cache.h"
+#include "tensorstore/internal/intrusive_ptr.h"
+#include "tensorstore/kvstore/kvstore.h"
+#include "tensorstore/kvstore/operations.h"
+#include "tensorstore/util/executor.h"
+#include "tensorstore/util/status.h"
+#include "tensorstore/util/status_testutil.h"
+
+namespace {
+
+using ::tensorstore::Context;
+using ::tensorstore::InlineExecutor;
+using ::tensorstore::internal::CachePool;
+using ::tensorstore::internal::GetCache;
+using ::tensorstore::internal_tiff_kvstore::TiffDirectoryCache;
+
+// Creates test data of specified size filled with 'X' pattern
+absl::Cord CreateTestData(size_t size) {
+  return absl::Cord(std::string(size, 'X'));
+}
+
+TEST(TiffDirectoryCacheTest, ReadSlice) {
+  auto context = Context::Default();
+  auto pool = CachePool::Make(CachePool::Limits{});
+
+  // Create an in-memory kvstore with test data
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      tensorstore::KvStore memory,
+      tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
+
+  ASSERT_THAT(
+      tensorstore::kvstore::Write(memory, "test.tiff", CreateTestData(2048))
+          .result(),
+      ::tensorstore::IsOk());
+
+  auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
+    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+  });
+
+  auto entry = GetCacheEntry(cache, "test.tiff");
+
+  // Request with specified range - should read first 1024 bytes
+  {
+    tensorstore::internal::AsyncCache::AsyncCacheReadRequest request;
+    request.staleness_bound = absl::InfinitePast();
+
+    ASSERT_THAT(entry->Read(request).result(), ::tensorstore::IsOk());
+
+    TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(*entry);
+    auto* data = lock.data();
+    ASSERT_THAT(data, ::testing::NotNull());
+    EXPECT_EQ(data->raw_data.size(), 1024);
+    EXPECT_FALSE(data->full_read);
+  }
+}
+
+TEST(TiffDirectoryCacheTest, ReadFull) {
+  auto context = Context::Default();
+  auto pool = CachePool::Make(CachePool::Limits{});
+
+  // Create an in-memory kvstore with test data
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      tensorstore::KvStore memory,
+      tensorstore::kvstore::Open({{"driver", "memory"}}, context).result());
+
+  ASSERT_THAT(
+      tensorstore::kvstore::Write(memory, "test.tiff", CreateTestData(512))
+          .result(),
+      ::tensorstore::IsOk());
+
+  auto cache = GetCache<TiffDirectoryCache>(pool.get(), "", [&] {
+    return std::make_unique<TiffDirectoryCache>(memory.driver, InlineExecutor{});
+  });
+
+  auto entry = GetCacheEntry(cache, "test.tiff");
+
+  // Request with no specified range - should read entire file
+  {
+    tensorstore::internal::AsyncCache::AsyncCacheReadRequest request;
+    request.staleness_bound = absl::InfinitePast();
+
+    ASSERT_THAT(entry->Read(request).result(), ::tensorstore::IsOk());
+
+    TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(*entry);
+    auto* data = lock.data();
+    ASSERT_THAT(data, ::testing::NotNull());
+    EXPECT_EQ(data->raw_data.size(), 512);
+    EXPECT_TRUE(data->full_read);
+  }
+}
+
+}  // namespace

--- a/tensorstore/kvstore/tiff/tiff_key_value_store.cc
+++ b/tensorstore/kvstore/tiff/tiff_key_value_store.cc
@@ -469,7 +469,7 @@ Future<kvstore::DriverPtr> Spec::DoOpen() const {
                           drv->header_raw_    = hdr_rr.value;
                           drv->header_parsed_ = hdr;
                           drv->first_ifd_     = std::move(dir);
-                          ABSL_LOG(INFO) << "TIFF open: "
+                          ABSL_LOG_IF(INFO, tiff_logging) << "TIFF open: "
                                          << drv->first_ifd_.width << "x"
                                          << drv->first_ifd_.height
                                          << (drv->first_ifd_.tiled?" tiled":" stripped");

--- a/tensorstore/kvstore/tiff/tiff_key_value_store.cc
+++ b/tensorstore/kvstore/tiff/tiff_key_value_store.cc
@@ -1,0 +1,502 @@
+// Copyright 2024 The TensorStore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// -----------------------------------------------------------------------------
+// TIFF key‑value‑store adapter
+//   * read‑only
+//   * validates the 8‑byte header during DoOpen
+//   * all other operations are simple pass‑through for now
+// -----------------------------------------------------------------------------
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <cstring>
+#include <array>
+#include <vector>
+#include <optional>
+
+#include "absl/status/status.h"
+#include "absl/strings/cord.h"
+#include "absl/strings/strip.h"
+#include "absl/log/absl_log.h"
+#include "absl/strings/str_cat.h"
+#include "tensorstore/context.h"
+#include "tensorstore/internal/cache/cache_pool_resource.h"
+#include "tensorstore/internal/data_copy_concurrency_resource.h"
+#include "tensorstore/internal/json_binding/json_binding.h"
+#include "tensorstore/kvstore/byte_range.h"
+#include "tensorstore/kvstore/driver.h"
+#include "tensorstore/kvstore/key_range.h"
+#include "tensorstore/kvstore/kvstore.h"
+#include "tensorstore/kvstore/operations.h"
+#include "tensorstore/kvstore/registry.h"
+#include "tensorstore/kvstore/spec.h"
+#include "tensorstore/transaction.h"
+#include "tensorstore/util/executor.h"
+#include "tensorstore/util/future.h"
+#include "tensorstore/util/quote_string.h"
+#include "tensorstore/util/result.h"
+#include "tensorstore/util/str_cat.h"
+
+namespace tensorstore::kvstore::tiff_kvstore {
+namespace jb = ::tensorstore::internal_json_binding;
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Endian helpers + header parser
+// ─────────────────────────────────────────────────────────────────────────────
+enum class Endian { kLittle, kBig };
+
+inline uint16_t Read16(const char* p, Endian e) {
+  return e == Endian::kLittle
+             ? uint16_t(uint8_t(p[0])) | (uint16_t(uint8_t(p[1])) << 8)
+             : uint16_t(uint8_t(p[1])) | (uint16_t(uint8_t(p[0])) << 8);
+}
+
+inline uint32_t Read32(const char* p, Endian e) {
+  if (e == Endian::kLittle)
+    return uint32_t(uint8_t(p[0])) | (uint32_t(uint8_t(p[1])) << 8) |
+           (uint32_t(uint8_t(p[2])) << 16) | (uint32_t(uint8_t(p[3])) << 24);
+  return uint32_t(uint8_t(p[3])) | (uint32_t(uint8_t(p[2])) << 8) |
+         (uint32_t(uint8_t(p[1])) << 16) | (uint32_t(uint8_t(p[0])) << 24);
+}
+
+enum Tag : uint16_t {
+  kImageWidth        = 256,
+  kImageLength       = 257,
+  kBitsPerSample     = 258,
+  kCompression       = 259,
+  kPhotometric       = 262,
+  kStripOffsets      = 273,
+  kRowsPerStrip      = 278,
+  kStripByteCounts   = 279,
+  kTileWidth         = 322,
+  kTileLength        = 323,
+  kTileOffsets       = 324,
+  kTileByteCounts    = 325,
+};
+
+enum Type : uint16_t { kBYTE=1, kSHORT=3, kLONG=4 };
+
+inline size_t TypeSize(Type t) {
+  switch(t) {
+    case kBYTE:  return 1;
+    case kSHORT: return 2;
+    case kLONG:  return 4;
+    default:     return 0;
+  }
+}
+
+struct IfdEntry {
+  Tag      tag;
+  Type     type;
+  uint32_t count;
+  uint32_t value_or_offset;   // raw
+};
+
+struct TiffHeader {
+  Endian   endian;
+  uint32_t first_ifd_offset;
+};
+
+struct ImageDirectory {
+  // ───────── raw tags we keep ─────────
+  uint32_t width            = 0;
+  uint32_t height           = 0;
+  uint32_t tile_width       = 0;          // 0 ⇒ striped
+  uint32_t tile_length      = 0;          // 0 ⇒ striped
+  uint32_t rows_per_strip   = 0;          // striped only
+  std::vector<uint64_t> chunk_offsets;     // tile or strip
+  std::vector<uint64_t> chunk_bytecounts;  // tile or strip
+  bool      tiled           = false;
+
+  // ───────── derived, filled after parsing ─────────
+  uint32_t chunk_rows = 0;    // number of chunk rows
+  uint32_t chunk_cols = 0;    // number of chunk cols
+};
+
+template <typename T>
+static inline T CeilDiv(T a, T b) { return (a + b - 1) / b; }
+
+inline absl::Status ParseHeader(const absl::Cord& c, TiffHeader& hdr) {
+  if (c.size() < 8) return absl::DataLossError("Header truncated (<8 bytes)");
+  char buf[8];
+  std::string tmp(c.Subcord(0, 8));   // makes a flat copy of those 8 bytes
+  std::memcpy(buf, tmp.data(), 8);
+
+  if (buf[0] == 'I' && buf[1] == 'I')
+    hdr.endian = Endian::kLittle;
+  else if (buf[0] == 'M' && buf[1] == 'M')
+    hdr.endian = Endian::kBig;
+  else
+    return absl::InvalidArgumentError("Bad byte‑order mark");
+
+  if (Read16(buf + 2, hdr.endian) != 42)
+    return absl::InvalidArgumentError("Missing 42 magic");
+
+  hdr.first_ifd_offset = Read32(buf + 4, hdr.endian);
+  return absl::OkStatus();
+}
+
+inline absl::Status ParseIfd(const absl::Cord& c,
+                             size_t ifd_offset,
+                             Endian e,
+                             ImageDirectory& out) {
+  // 1. copy 2 bytes count
+  if (c.size() < ifd_offset + 2)
+    return absl::DataLossError("IFD truncated (count)");
+  char cnt_buf[2];
+  std::string tmp(c.Subcord(0, 2));
+  std::memcpy(cnt_buf, tmp.data(), 2);
+//  c.CopyTo(cnt_buf, ifd_offset, 2);
+  uint16_t entry_count = Read16(cnt_buf, e);
+
+  // 2. copy entries (12 bytes each)
+  size_t table_size = size_t(entry_count) * 12;
+  if (c.size() < ifd_offset + 2 + table_size + 4)
+    return absl::DataLossError("IFD truncated (entries)");
+
+  std::string table(c.Subcord(ifd_offset + 2, table_size));
+  const char* p = table.data();
+  std::vector<IfdEntry> entries;
+  entries.reserve(entry_count);
+  for (uint16_t i=0;i<entry_count;++i, p+=12) {
+    IfdEntry e2;
+    e2.tag  = Tag(Read16(p, e));
+    e2.type = Type(Read16(p+2, e));
+    e2.count = Read32(p+4, e);
+    e2.value_or_offset = Read32(p+8, e);
+    entries.push_back(e2);
+  }
+
+  // helpers
+  auto find = [&](Tag t)->const IfdEntry*{
+    for(auto& v:entries) if (v.tag==t) return &v;
+    return nullptr;
+  };
+  auto fetch_scalar = [&](Tag t, uint32_t* dst)->absl::Status{
+    auto* ent=find(t);
+    if(!ent) return absl::NotFoundError("Missing tag");
+    if(ent->count!=1) return absl::InvalidArgumentError("Bad count");
+    if(ent->type==kSHORT) *dst = ent->value_or_offset & 0xFFFFu;
+    else if(ent->type==kLONG) *dst = ent->value_or_offset;
+    else return absl::InvalidArgumentError("Unexpected type");
+    return absl::OkStatus();
+  };
+
+  TENSORSTORE_RETURN_IF_ERROR(fetch_scalar(kImageWidth , &out.width ));
+  TENSORSTORE_RETURN_IF_ERROR(fetch_scalar(kImageLength, &out.height));
+
+  // Decide tiled vs strips
+  if (find(kTileOffsets)) {
+    out.tiled = true;
+    TENSORSTORE_RETURN_IF_ERROR(fetch_scalar(kTileWidth , &out.tile_width ));
+    TENSORSTORE_RETURN_IF_ERROR(fetch_scalar(kTileLength, &out.tile_length));
+  } else {
+    out.tiled = false;
+    TENSORSTORE_RETURN_IF_ERROR(fetch_scalar(kRowsPerStrip, &out.rows_per_strip));
+  }
+  
+  // Offsets & byte counts
+  auto load_array = [&](const IfdEntry* ent,
+                        std::vector<uint64_t>* vec)->absl::Status{
+    if(!ent) return absl::NotFoundError("Missing required tag");
+    size_t elem_sz = TypeSize(ent->type);
+    if(!(ent->type==kSHORT || ent->type==kLONG))
+      return absl::InvalidArgumentError("Unsupported type in array");
+    size_t total = size_t(ent->count)*elem_sz;
+    size_t src_off = (ent->count==1 && total<=4)
+                     ? std::numeric_limits<size_t>::max()  // value in place
+                     : ent->value_or_offset;
+    std::string buf;
+    if(src_off==std::numeric_limits<size_t>::max()) {
+      buf.assign(reinterpret_cast<const char*>(&ent->value_or_offset),4);
+    } else {
+      if(c.size()<src_off+total)
+        return absl::DataLossError("Array out of file bounds");
+      buf.assign(std::string(c.Subcord(src_off, total)));
+    }
+    vec->resize(ent->count);
+    for(uint32_t i=0;i<ent->count;++i) {
+      if(ent->type==kSHORT)
+        (*vec)[i] = Read16(buf.data()+i*elem_sz,e);
+      else
+        (*vec)[i] = Read32(buf.data()+i*elem_sz,e);
+    }
+
+    return absl::OkStatus();
+  };
+
+  TENSORSTORE_RETURN_IF_ERROR(
+      load_array(find(out.tiled?kTileOffsets:kStripOffsets), &out.chunk_offsets));
+  TENSORSTORE_RETURN_IF_ERROR(
+      load_array(find(out.tiled?kTileByteCounts:kStripByteCounts),
+                 &out.chunk_bytecounts));
+
+  if(out.chunk_offsets.size()!=out.chunk_bytecounts.size())
+    return absl::InvalidArgumentError("Offsets/ByteCounts length mismatch");
+
+  // ------------------------------------------------------------------
+  // Consistency & derived values
+  // ------------------------------------------------------------------
+  if (out.tiled) {
+    out.chunk_cols = CeilDiv(out.width , out.tile_width );
+    out.chunk_rows = CeilDiv(out.height, out.tile_length);
+  } else {                           // striped
+    out.tile_width  = out.width;     // pretend full‑width tiles
+    out.tile_length = out.rows_per_strip;
+    out.chunk_cols  = 1;
+    out.chunk_rows  = out.chunk_offsets.size();
+  }
+
+  return absl::OkStatus();
+}
+
+// Expected key: "tile/<ifd>/<row>/<col>"
+absl::Status ParseTileKey(std::string_view key,
+                          uint32_t& ifd, uint32_t& row, uint32_t& col) {
+  auto eat_number = [&](std::string_view& s, uint32_t& out) -> bool {
+    if (s.empty()) return false;
+    uint32_t v = 0;
+    size_t i = 0;
+    while (i < s.size() && s[i] >= '0' && s[i] <= '9') {
+      v = v * 10 + (s[i] - '0');
+      ++i;
+    }
+    if (i == 0) return false;           // no digits
+    out = v;
+    s.remove_prefix(i);
+    return true;
+  };
+
+  if (!absl::ConsumePrefix(&key, "tile/")) {
+    return absl::InvalidArgumentError("Key must start with \"tile/\"");
+  }
+  if (!eat_number(key, ifd) || !absl::ConsumePrefix(&key, "/") ||
+      !eat_number(key, row) || !absl::ConsumePrefix(&key, "/") ||
+      !eat_number(key, col) || !key.empty()) {
+    return absl::InvalidArgumentError("Bad tile key format");
+  }
+  return absl::OkStatus();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Spec‑data (JSON parameters)
+// ─────────────────────────────────────────────────────────────────────────────
+struct TiffKvStoreSpecData {
+  kvstore::Spec base;
+  Context::Resource<internal::CachePoolResource> cache_pool;
+  Context::Resource<internal::DataCopyConcurrencyResource> data_copy;
+
+  constexpr static auto ApplyMembers = [](auto& x, auto f) {
+    return f(x.base, x.cache_pool, x.data_copy);
+  };
+
+  constexpr static auto default_json_binder = jb::Object(
+      jb::Member("base", jb::Projection<&TiffKvStoreSpecData::base>()),
+      jb::Member(internal::CachePoolResource::id,
+                 jb::Projection<&TiffKvStoreSpecData::cache_pool>()),
+      jb::Member(internal::DataCopyConcurrencyResource::id,
+                 jb::Projection<&TiffKvStoreSpecData::data_copy>()));
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Spec
+// ─────────────────────────────────────────────────────────────────────────────
+struct Spec
+    : public internal_kvstore::RegisteredDriverSpec<Spec,
+                                                    TiffKvStoreSpecData> {
+  static constexpr char id[] = "tiff";
+
+  Future<kvstore::DriverPtr> DoOpen() const override;
+
+  absl::Status ApplyOptions(kvstore::DriverSpecOptions&& o) override {
+    return data_.base.driver.Set(std::move(o));
+  }
+  Result<kvstore::Spec> GetBase(std::string_view) const override {
+    return data_.base;
+  }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Driver
+// ─────────────────────────────────────────────────────────────────────────────
+class TiffKeyValueStore
+    : public internal_kvstore::RegisteredDriver<TiffKeyValueStore, Spec> {
+ public:
+ Future<ReadResult> Read(Key key, ReadOptions opts) {
+    uint32_t ifd, row, col;
+    if (auto st = ParseTileKey(key, ifd, row, col); !st.ok()) {
+      return MakeReadyFuture<ReadResult>(st);          // fast fail
+    }
+
+    // 1. Bounds‑check against cached first IFD info
+    if (ifd != 0) {   // we only cached IFD 0 so far
+      return MakeReadyFuture<ReadResult>(
+          absl::UnimplementedError("Only IFD 0 implemented"));
+    }
+    if (row >= first_ifd_.chunk_rows || col >= first_ifd_.chunk_cols) {
+      return MakeReadyFuture<ReadResult>(
+          absl::OutOfRangeError("Tile/strip index out of range"));
+    }
+
+    // 2. Compute byte range
+    size_t tile_index   = row * first_ifd_.chunk_cols + col;
+    uint64_t offset     = first_ifd_.chunk_offsets[tile_index];
+    uint64_t byte_count = first_ifd_.chunk_bytecounts[tile_index];
+
+    ReadOptions ro;
+    ro.byte_range = OptionalByteRangeRequest::Range(offset, offset + byte_count);
+    ro.staleness_bound = opts.staleness_bound;  // propagate
+
+    return base_.driver->Read(base_.path, std::move(ro));
+  }
+
+  // ------------------------------------------------------------------
+  // List  (unchanged)
+  // ------------------------------------------------------------------
+  void ListImpl(ListOptions options, ListReceiver receiver) override {
+    options.range = KeyRange::AddPrefix(base_.path, options.range);
+    base_.driver->ListImpl(std::move(options), std::move(receiver));
+  }
+
+  // ------------------------------------------------------------------
+  // Misc helpers
+  // ------------------------------------------------------------------
+  std::string DescribeKey(std::string_view key) override {
+    return StrCat(QuoteString(key), " in ",
+                  base_.driver->DescribeKey(base_.path));
+  }
+  SupportedFeatures GetSupportedFeatures(const KeyRange& r) const override {
+    return base_.driver->GetSupportedFeatures(
+        KeyRange::AddPrefix(base_.path, r));
+  }
+  Result<KvStore> GetBase(std::string_view, const Transaction& t) const override {
+    return KvStore(base_.driver, base_.path, t);
+  }
+  const Executor& executor() const { return spec_data_.data_copy->executor; }
+
+  absl::Status GetBoundSpecData(TiffKvStoreSpecData& spec) const {
+    spec = spec_data_;
+    return absl::OkStatus();
+  }
+
+  // ------------------------------------------------------------------
+  // Data members
+  // ------------------------------------------------------------------
+  TiffKvStoreSpecData spec_data_;
+  kvstore::KvStore    base_;
+
+  // Newly stored header information
+  absl::Cord header_raw_;
+  TiffHeader header_parsed_;
+  ImageDirectory first_ifd_;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Spec::DoOpen  (now reads & validates the 8‑byte header)
+// ─────────────────────────────────────────────────────────────────────────────
+Future<kvstore::DriverPtr> Spec::DoOpen() const {
+  // 1. Open the underlying kvstore.
+  auto base_future = kvstore::Open(data_.base);
+
+  // 2. Once base opens, issue an 8‑byte range read, validate, then build driver.
+  return MapFutureValue(
+      InlineExecutor{},
+      [spec = internal::IntrusivePtr<const Spec>(this)](
+          kvstore::KvStore& base_kv) mutable -> Future<kvstore::DriverPtr> {
+        // ---- read first 8 bytes
+        ReadOptions hdr_opt;
+        hdr_opt.byte_range =
+            OptionalByteRangeRequest::Range(0, 8);  // header only
+        auto hdr_future =
+            base_kv.driver->Read(base_kv.path, std::move(hdr_opt));
+        
+            // ---- parse & construct driver
+        return MapFutureValue(
+            InlineExecutor{},
+            [spec, base_kv](const ReadResult& hdr_rr)
+                -> Future<kvstore::DriverPtr> {
+              TiffHeader hdr;
+              TENSORSTORE_RETURN_IF_ERROR(ParseHeader(hdr_rr.value, hdr));
+
+              // Read 2‑byte count first
+              ReadOptions cnt_opt;
+              cnt_opt.byte_range =
+                  OptionalByteRangeRequest::Range(hdr.first_ifd_offset, hdr.first_ifd_offset+2);
+              auto cnt_future =
+                  base_kv.driver->Read(base_kv.path, cnt_opt);
+
+              return MapFutureValue(
+                  InlineExecutor{},
+                  [spec, base_kv, hdr, hdr_rr](const ReadResult& cnt_rr)
+                      -> Future<kvstore::DriverPtr> {
+                    
+                    uint16_t n_entries =
+                        Read16(std::string(cnt_rr.value).data(), hdr.endian);
+                    size_t ifd_bytes = 2 + size_t(n_entries)*12 + 4;
+
+                    ReadOptions ifd_opt;
+                    ifd_opt.byte_range = OptionalByteRangeRequest::Range(
+                        hdr.first_ifd_offset, hdr.first_ifd_offset + ifd_bytes);
+                    auto ifd_future =
+                        base_kv.driver->Read(base_kv.path, ifd_opt);
+
+                    return MapFutureValue(
+                        InlineExecutor{},
+                        [spec, base_kv, hdr, hdr_rr](const ReadResult& ifd_rr)
+                            -> Result<kvstore::DriverPtr> {
+                          ImageDirectory dir;
+                          TENSORSTORE_RETURN_IF_ERROR(
+                              ParseIfd(ifd_rr.value, 0, hdr.endian, dir));
+
+                          // Construct driver
+                          auto drv   = internal::MakeIntrusivePtr<TiffKeyValueStore>();
+                          drv->base_ = base_kv;
+                          drv->spec_data_ = spec->data_;
+                          drv->header_raw_    = hdr_rr.value;
+                          drv->header_parsed_ = hdr;
+                          drv->first_ifd_     = std::move(dir);
+                          ABSL_LOG(INFO) << "TIFF open: "
+                                         << drv->first_ifd_.width << "x"
+                                         << drv->first_ifd_.height
+                                         << (drv->first_ifd_.tiled?" tiled":" stripped");
+                          return kvstore::DriverPtr(drv);
+                        },
+                        ifd_future);
+                  },
+                  cnt_future);
+            },
+            std::move(hdr_future));
+      },
+      std::move(base_future));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  GC declaration (driver holds no GC‑relevant objects)
+// ─────────────────────────────────────────────────────────────────────────────
+}  // namespace tensorstore::kvstore::tiff_kvstore
+
+TENSORSTORE_DECLARE_GARBAGE_COLLECTION_NOT_REQUIRED(
+    tensorstore::kvstore::tiff_kvstore::TiffKeyValueStore)
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Registration
+// ─────────────────────────────────────────────────────────────────────────────
+namespace {
+const tensorstore::internal_kvstore::DriverRegistration<
+    tensorstore::kvstore::tiff_kvstore::Spec>
+    registration;
+}  // namespace

--- a/tensorstore/kvstore/tiff/tiff_key_value_store.cc
+++ b/tensorstore/kvstore/tiff/tiff_key_value_store.cc
@@ -15,35 +15,41 @@
 // -----------------------------------------------------------------------------
 // TIFF key‑value‑store adapter
 //   * read‑only
-//   * validates the 8‑byte header during DoOpen
-//   * all other operations are simple pass‑through for now
+//   * uses TiffDirectoryCache for parsing TIFF file structure
+//   * supports tile or strip-based TIFF files
 // -----------------------------------------------------------------------------
 
-#include <cstdint>
+#include "tensorstore/kvstore/tiff/tiff_key_value_store.h"
+
+#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
-#include <cstring>
-#include <array>
-#include <vector>
-#include <optional>
 
+#include "absl/log/absl_log.h"
 #include "absl/status/status.h"
 #include "absl/strings/cord.h"
-#include "absl/strings/strip.h"
-#include "absl/log/absl_log.h"
-#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/strip.h"  // For ConsumePrefix
 #include "tensorstore/context.h"
+#include "tensorstore/internal/cache/async_cache.h"
+#include "tensorstore/internal/cache/cache.h"
 #include "tensorstore/internal/cache/cache_pool_resource.h"
+#include "tensorstore/internal/cache_key/cache_key.h"
 #include "tensorstore/internal/data_copy_concurrency_resource.h"
+#include "tensorstore/internal/intrusive_ptr.h"
 #include "tensorstore/internal/json_binding/json_binding.h"
+#include "tensorstore/internal/log/verbose_flag.h"
 #include "tensorstore/kvstore/byte_range.h"
 #include "tensorstore/kvstore/driver.h"
 #include "tensorstore/kvstore/key_range.h"
 #include "tensorstore/kvstore/kvstore.h"
 #include "tensorstore/kvstore/operations.h"
+#include "tensorstore/kvstore/read_result.h"
 #include "tensorstore/kvstore/registry.h"
 #include "tensorstore/kvstore/spec.h"
+#include "tensorstore/kvstore/tiff/tiff_details.h"
+#include "tensorstore/kvstore/tiff/tiff_dir_cache.h"
 #include "tensorstore/transaction.h"
 #include "tensorstore/util/executor.h"
 #include "tensorstore/util/future.h"
@@ -54,215 +60,14 @@
 namespace tensorstore::kvstore::tiff_kvstore {
 namespace jb = ::tensorstore::internal_json_binding;
 
-// ─────────────────────────────────────────────────────────────────────────────
-//  Endian helpers + header parser
-// ─────────────────────────────────────────────────────────────────────────────
-enum class Endian { kLittle, kBig };
+using ::tensorstore::internal_tiff_kvstore::ImageDirectory;
+using ::tensorstore::internal_tiff_kvstore::TiffDirectoryCache;
+using ::tensorstore::kvstore::ListEntry;
+using ::tensorstore::kvstore::ListReceiver;
 
-inline uint16_t Read16(const char* p, Endian e) {
-  return e == Endian::kLittle
-             ? uint16_t(uint8_t(p[0])) | (uint16_t(uint8_t(p[1])) << 8)
-             : uint16_t(uint8_t(p[1])) | (uint16_t(uint8_t(p[0])) << 8);
-}
+namespace {
 
-inline uint32_t Read32(const char* p, Endian e) {
-  if (e == Endian::kLittle)
-    return uint32_t(uint8_t(p[0])) | (uint32_t(uint8_t(p[1])) << 8) |
-           (uint32_t(uint8_t(p[2])) << 16) | (uint32_t(uint8_t(p[3])) << 24);
-  return uint32_t(uint8_t(p[3])) | (uint32_t(uint8_t(p[2])) << 8) |
-         (uint32_t(uint8_t(p[1])) << 16) | (uint32_t(uint8_t(p[0])) << 24);
-}
-
-enum Tag : uint16_t {
-  kImageWidth        = 256,
-  kImageLength       = 257,
-  kBitsPerSample     = 258,
-  kCompression       = 259,
-  kPhotometric       = 262,
-  kStripOffsets      = 273,
-  kRowsPerStrip      = 278,
-  kStripByteCounts   = 279,
-  kTileWidth         = 322,
-  kTileLength        = 323,
-  kTileOffsets       = 324,
-  kTileByteCounts    = 325,
-};
-
-enum Type : uint16_t { kBYTE=1, kSHORT=3, kLONG=4 };
-
-inline size_t TypeSize(Type t) {
-  switch(t) {
-    case kBYTE:  return 1;
-    case kSHORT: return 2;
-    case kLONG:  return 4;
-    default:     return 0;
-  }
-}
-
-struct IfdEntry {
-  Tag      tag;
-  Type     type;
-  uint32_t count;
-  uint32_t value_or_offset;   // raw
-};
-
-struct TiffHeader {
-  Endian   endian;
-  uint32_t first_ifd_offset;
-};
-
-struct ImageDirectory {
-  // ───────── raw tags we keep ─────────
-  uint32_t width            = 0;
-  uint32_t height           = 0;
-  uint32_t tile_width       = 0;          // 0 ⇒ striped
-  uint32_t tile_length      = 0;          // 0 ⇒ striped
-  uint32_t rows_per_strip   = 0;          // striped only
-  std::vector<uint64_t> chunk_offsets;     // tile or strip
-  std::vector<uint64_t> chunk_bytecounts;  // tile or strip
-  bool      tiled           = false;
-
-  // ───────── derived, filled after parsing ─────────
-  uint32_t chunk_rows = 0;    // number of chunk rows
-  uint32_t chunk_cols = 0;    // number of chunk cols
-};
-
-template <typename T>
-static inline T CeilDiv(T a, T b) { return (a + b - 1) / b; }
-
-inline absl::Status ParseHeader(const absl::Cord& c, TiffHeader& hdr) {
-  if (c.size() < 8) return absl::DataLossError("Header truncated (<8 bytes)");
-  char buf[8];
-  std::string tmp(c.Subcord(0, 8));   // makes a flat copy of those 8 bytes
-  std::memcpy(buf, tmp.data(), 8);
-
-  if (buf[0] == 'I' && buf[1] == 'I')
-    hdr.endian = Endian::kLittle;
-  else if (buf[0] == 'M' && buf[1] == 'M')
-    hdr.endian = Endian::kBig;
-  else
-    return absl::InvalidArgumentError("Bad byte‑order mark");
-
-  if (Read16(buf + 2, hdr.endian) != 42)
-    return absl::InvalidArgumentError("Missing 42 magic");
-
-  hdr.first_ifd_offset = Read32(buf + 4, hdr.endian);
-  return absl::OkStatus();
-}
-
-inline absl::Status ParseIfd(const absl::Cord& c,
-                             size_t ifd_offset,
-                             Endian e,
-                             ImageDirectory& out) {
-  // 1. copy 2 bytes count
-  if (c.size() < ifd_offset + 2)
-    return absl::DataLossError("IFD truncated (count)");
-  char cnt_buf[2];
-  std::string tmp(c.Subcord(0, 2));
-  std::memcpy(cnt_buf, tmp.data(), 2);
-//  c.CopyTo(cnt_buf, ifd_offset, 2);
-  uint16_t entry_count = Read16(cnt_buf, e);
-
-  // 2. copy entries (12 bytes each)
-  size_t table_size = size_t(entry_count) * 12;
-  if (c.size() < ifd_offset + 2 + table_size + 4)
-    return absl::DataLossError("IFD truncated (entries)");
-
-  std::string table(c.Subcord(ifd_offset + 2, table_size));
-  const char* p = table.data();
-  std::vector<IfdEntry> entries;
-  entries.reserve(entry_count);
-  for (uint16_t i=0;i<entry_count;++i, p+=12) {
-    IfdEntry e2;
-    e2.tag  = Tag(Read16(p, e));
-    e2.type = Type(Read16(p+2, e));
-    e2.count = Read32(p+4, e);
-    e2.value_or_offset = Read32(p+8, e);
-    entries.push_back(e2);
-  }
-
-  // helpers
-  auto find = [&](Tag t)->const IfdEntry*{
-    for(auto& v:entries) if (v.tag==t) return &v;
-    return nullptr;
-  };
-  auto fetch_scalar = [&](Tag t, uint32_t* dst)->absl::Status{
-    auto* ent=find(t);
-    if(!ent) return absl::NotFoundError("Missing tag");
-    if(ent->count!=1) return absl::InvalidArgumentError("Bad count");
-    if(ent->type==kSHORT) *dst = ent->value_or_offset & 0xFFFFu;
-    else if(ent->type==kLONG) *dst = ent->value_or_offset;
-    else return absl::InvalidArgumentError("Unexpected type");
-    return absl::OkStatus();
-  };
-
-  TENSORSTORE_RETURN_IF_ERROR(fetch_scalar(kImageWidth , &out.width ));
-  TENSORSTORE_RETURN_IF_ERROR(fetch_scalar(kImageLength, &out.height));
-
-  // Decide tiled vs strips
-  if (find(kTileOffsets)) {
-    out.tiled = true;
-    TENSORSTORE_RETURN_IF_ERROR(fetch_scalar(kTileWidth , &out.tile_width ));
-    TENSORSTORE_RETURN_IF_ERROR(fetch_scalar(kTileLength, &out.tile_length));
-  } else {
-    out.tiled = false;
-    TENSORSTORE_RETURN_IF_ERROR(fetch_scalar(kRowsPerStrip, &out.rows_per_strip));
-  }
-  
-  // Offsets & byte counts
-  auto load_array = [&](const IfdEntry* ent,
-                        std::vector<uint64_t>* vec)->absl::Status{
-    if(!ent) return absl::NotFoundError("Missing required tag");
-    size_t elem_sz = TypeSize(ent->type);
-    if(!(ent->type==kSHORT || ent->type==kLONG))
-      return absl::InvalidArgumentError("Unsupported type in array");
-    size_t total = size_t(ent->count)*elem_sz;
-    size_t src_off = (ent->count==1 && total<=4)
-                     ? std::numeric_limits<size_t>::max()  // value in place
-                     : ent->value_or_offset;
-    std::string buf;
-    if(src_off==std::numeric_limits<size_t>::max()) {
-      buf.assign(reinterpret_cast<const char*>(&ent->value_or_offset),4);
-    } else {
-      if(c.size()<src_off+total)
-        return absl::DataLossError("Array out of file bounds");
-      buf.assign(std::string(c.Subcord(src_off, total)));
-    }
-    vec->resize(ent->count);
-    for(uint32_t i=0;i<ent->count;++i) {
-      if(ent->type==kSHORT)
-        (*vec)[i] = Read16(buf.data()+i*elem_sz,e);
-      else
-        (*vec)[i] = Read32(buf.data()+i*elem_sz,e);
-    }
-
-    return absl::OkStatus();
-  };
-
-  TENSORSTORE_RETURN_IF_ERROR(
-      load_array(find(out.tiled?kTileOffsets:kStripOffsets), &out.chunk_offsets));
-  TENSORSTORE_RETURN_IF_ERROR(
-      load_array(find(out.tiled?kTileByteCounts:kStripByteCounts),
-                 &out.chunk_bytecounts));
-
-  if(out.chunk_offsets.size()!=out.chunk_bytecounts.size())
-    return absl::InvalidArgumentError("Offsets/ByteCounts length mismatch");
-
-  // ------------------------------------------------------------------
-  // Consistency & derived values
-  // ------------------------------------------------------------------
-  if (out.tiled) {
-    out.chunk_cols = CeilDiv(out.width , out.tile_width );
-    out.chunk_rows = CeilDiv(out.height, out.tile_length);
-  } else {                           // striped
-    out.tile_width  = out.width;     // pretend full‑width tiles
-    out.tile_length = out.rows_per_strip;
-    out.chunk_cols  = 1;
-    out.chunk_rows  = out.chunk_offsets.size();
-  }
-
-  return absl::OkStatus();
-}
+ABSL_CONST_INIT internal_log::VerboseFlag tiff_logging("tiff");
 
 // Expected key: "tile/<ifd>/<row>/<col>"
 absl::Status ParseTileKey(std::string_view key,
@@ -298,10 +103,10 @@ absl::Status ParseTileKey(std::string_view key,
 struct TiffKvStoreSpecData {
   kvstore::Spec base;
   Context::Resource<internal::CachePoolResource> cache_pool;
-  Context::Resource<internal::DataCopyConcurrencyResource> data_copy;
+  Context::Resource<internal::DataCopyConcurrencyResource> data_copy_concurrency;
 
   constexpr static auto ApplyMembers = [](auto& x, auto f) {
-    return f(x.base, x.cache_pool, x.data_copy);
+    return f(x.base, x.cache_pool, x.data_copy_concurrency);
   };
 
   constexpr static auto default_json_binder = jb::Object(
@@ -309,7 +114,7 @@ struct TiffKvStoreSpecData {
       jb::Member(internal::CachePoolResource::id,
                  jb::Projection<&TiffKvStoreSpecData::cache_pool>()),
       jb::Member(internal::DataCopyConcurrencyResource::id,
-                 jb::Projection<&TiffKvStoreSpecData::data_copy>()));
+                 jb::Projection<&TiffKvStoreSpecData::data_copy_concurrency>()));
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -336,157 +141,354 @@ struct Spec
 class TiffKeyValueStore
     : public internal_kvstore::RegisteredDriver<TiffKeyValueStore, Spec> {
  public:
- Future<ReadResult> Read(Key key, ReadOptions opts) {
-    uint32_t ifd, row, col;
-    if (auto st = ParseTileKey(key, ifd, row, col); !st.ok()) {
-      return MakeReadyFuture<ReadResult>(st);          // fast fail
-    }
+  Future<ReadResult> Read(Key key, ReadOptions options) override;
+  
+  void ListImpl(ListOptions options, ListReceiver receiver) override;
 
-    // 1. Bounds‑check against cached first IFD info
-    if (ifd != 0) {   // we only cached IFD 0 so far
-      return MakeReadyFuture<ReadResult>(
-          absl::UnimplementedError("Only IFD 0 implemented"));
-    }
-    if (row >= first_ifd_.chunk_rows || col >= first_ifd_.chunk_cols) {
-      return MakeReadyFuture<ReadResult>(
-          absl::OutOfRangeError("Tile/strip index out of range"));
-    }
-
-    // 2. Compute byte range
-    size_t tile_index   = row * first_ifd_.chunk_cols + col;
-    uint64_t offset     = first_ifd_.chunk_offsets[tile_index];
-    uint64_t byte_count = first_ifd_.chunk_bytecounts[tile_index];
-
-    ReadOptions ro;
-    ro.byte_range = OptionalByteRangeRequest::Range(offset, offset + byte_count);
-    ro.staleness_bound = opts.staleness_bound;  // propagate
-
-    return base_.driver->Read(base_.path, std::move(ro));
-  }
-
-  // ------------------------------------------------------------------
-  // List  (unchanged)
-  // ------------------------------------------------------------------
-  void ListImpl(ListOptions options, ListReceiver receiver) override {
-    options.range = KeyRange::AddPrefix(base_.path, options.range);
-    base_.driver->ListImpl(std::move(options), std::move(receiver));
-  }
-
-  // ------------------------------------------------------------------
-  // Misc helpers
-  // ------------------------------------------------------------------
   std::string DescribeKey(std::string_view key) override {
     return StrCat(QuoteString(key), " in ",
                   base_.driver->DescribeKey(base_.path));
   }
+  
   SupportedFeatures GetSupportedFeatures(const KeyRange& r) const override {
     return base_.driver->GetSupportedFeatures(
         KeyRange::AddPrefix(base_.path, r));
   }
+  
   Result<KvStore> GetBase(std::string_view, const Transaction& t) const override {
     return KvStore(base_.driver, base_.path, t);
   }
-  const Executor& executor() const { return spec_data_.data_copy->executor; }
+  
+  const Executor& executor() const { return spec_data_.data_copy_concurrency->executor; }
 
   absl::Status GetBoundSpecData(TiffKvStoreSpecData& spec) const {
     spec = spec_data_;
     return absl::OkStatus();
   }
 
-  // ------------------------------------------------------------------
-  // Data members
-  // ------------------------------------------------------------------
   TiffKvStoreSpecData spec_data_;
-  kvstore::KvStore    base_;
+  kvstore::KvStore base_;
+  internal::PinnedCacheEntry<TiffDirectoryCache> cache_entry_;
+};
 
-  // Newly stored header information
-  absl::Cord header_raw_;
-  TiffHeader header_parsed_;
-  ImageDirectory first_ifd_;
+// Implements TiffKeyValueStore::Read
+struct ReadState : public internal::AtomicReferenceCount<ReadState> {
+  internal::IntrusivePtr<TiffKeyValueStore> owner_;
+  kvstore::Key key_;
+  kvstore::ReadOptions options_;
+  uint32_t ifd_, row_, col_;
+
+  void OnDirectoryReady(Promise<kvstore::ReadResult> promise) {
+    TimestampedStorageGeneration stamp;
+
+    // Set options for the chunk read request
+    kvstore::ReadOptions options;
+    options.staleness_bound = options_.staleness_bound;
+    options.byte_range = OptionalByteRangeRequest{};
+    
+    // Store original byte range for later use
+    OptionalByteRangeRequest original_byte_range = options_.byte_range;
+
+    {
+      TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(
+          *(owner_->cache_entry_));
+      stamp = lock.stamp();
+
+      // Get directory data and verify ifd_ is valid (only ifd 0 for now)
+      assert(lock.data());
+      const auto& dir = lock.data()->image_directory;
+      
+      if (ifd_ != 0) {
+        promise.SetResult(absl::UnimplementedError("Only IFD 0 implemented"));
+        return;
+      }
+
+      // Check if tile/strip indices are in bounds
+      uint32_t chunk_rows, chunk_cols;
+      uint64_t offset, byte_count;
+      
+      if (dir.tile_width > 0) {
+        // Tiled TIFF
+        chunk_rows = (dir.height + dir.tile_height - 1) / dir.tile_height;
+        chunk_cols = (dir.width + dir.tile_width - 1) / dir.tile_width;
+        
+        if (row_ >= chunk_rows || col_ >= chunk_cols) {
+          promise.SetResult(absl::OutOfRangeError("Tile index out of range"));
+          return;
+        }
+        
+        // Calculate tile index and get offset/size
+        size_t tile_index = row_ * chunk_cols + col_;
+        if (tile_index >= dir.tile_offsets.size()) {
+          promise.SetResult(absl::OutOfRangeError("Tile index out of range"));
+          return;
+        }
+        
+        offset = dir.tile_offsets[tile_index];
+        byte_count = dir.tile_bytecounts[tile_index];
+      } else {
+        // Strip-based TIFF
+        chunk_rows = dir.strip_offsets.size();
+        chunk_cols = 1;
+        
+        if (row_ >= chunk_rows || col_ != 0) {
+          promise.SetResult(absl::OutOfRangeError("Strip index out of range"));
+          return;
+        }
+        
+        // Get strip offset/size
+        offset = dir.strip_offsets[row_];
+        byte_count = dir.strip_bytecounts[row_];
+      }
+
+      // Check if_equal and if_not_equal conditions
+      if (!options_.generation_conditions.Matches(stamp.generation)) {
+        promise.SetResult(kvstore::ReadResult::Unspecified(std::move(stamp)));
+        return;
+      }
+      
+      options.byte_range = OptionalByteRangeRequest::Range(
+          offset, offset + byte_count);
+    }
+
+    options.generation_conditions.if_equal = stamp.generation;
+    
+    // Issue read for the tile/strip data
+    auto future = owner_->base_.driver->Read(owner_->base_.path, std::move(options));
+    future.Force();
+    future.ExecuteWhenReady(
+        [self = internal::IntrusivePtr<ReadState>(this), 
+         original_byte_range = std::move(original_byte_range),
+         promise = std::move(promise)](
+            ReadyFuture<kvstore::ReadResult> ready) mutable {
+          if (!ready.result().ok()) {
+            promise.SetResult(std::move(ready.result()));
+            return;
+          }
+          
+          auto read_result = std::move(ready.result().value());
+          if (!read_result.has_value()) {
+            promise.SetResult(std::move(read_result));
+            return;
+          }
+          
+          // Apply byte range to the result if needed
+          if (!original_byte_range.IsFull()) {
+            // Validate the byte range against the actual size of the data
+            auto size = read_result.value.size();
+            auto byte_range_result = original_byte_range.Validate(size);
+            
+            if (!byte_range_result.ok()) {
+              promise.SetResult(std::move(byte_range_result.status()));
+              return;
+            }
+            
+            // Apply the validated byte range
+            ByteRange byte_range = byte_range_result.value();
+            if (byte_range.inclusive_min > 0 || byte_range.exclusive_max < size) {
+              read_result.value = read_result.value.Subcord(
+                  byte_range.inclusive_min, byte_range.size());
+            }
+          }
+          
+          promise.SetResult(std::move(read_result));
+        });
+  }
+};
+
+// Implements TiffKeyValueStore::List
+struct ListState : public internal::AtomicReferenceCount<ListState> {
+  internal::IntrusivePtr<TiffKeyValueStore> owner_;
+  kvstore::ListOptions options_;
+  ListReceiver receiver_;
+  Promise<void> promise_;
+  Future<void> future_;
+
+  ListState(internal::IntrusivePtr<TiffKeyValueStore>&& owner,
+            kvstore::ListOptions&& options, ListReceiver&& receiver)
+      : owner_(std::move(owner)),
+        options_(std::move(options)),
+        receiver_(std::move(receiver)) {
+    auto [promise, future] = PromiseFuturePair<void>::Make(MakeResult());
+    this->promise_ = std::move(promise);
+    this->future_ = std::move(future);
+    future_.Force();
+    execution::set_starting(receiver_, [promise = promise_] {
+      promise.SetResult(absl::CancelledError(""));
+    });
+  }
+
+  ~ListState() {
+    auto& r = promise_.raw_result();
+    if (r.ok()) {
+      execution::set_done(receiver_);
+    } else {
+      execution::set_error(receiver_, r.status());
+    }
+    execution::set_stopping(receiver_);
+  }
+
+  void OnDirectoryReady() {
+    TiffDirectoryCache::ReadLock<TiffDirectoryCache::ReadData> lock(
+        *(owner_->cache_entry_));
+      
+    // Get directory information
+    assert(lock.data());
+    const auto& dir = lock.data()->image_directory;
+    
+    // Currently only support IFD 0
+    // Determine number of tiles/strips
+    uint32_t chunk_rows, chunk_cols;
+    if (dir.tile_width > 0) {
+      // Tiled TIFF
+      chunk_rows = (dir.height + dir.tile_height - 1) / dir.tile_height;
+      chunk_cols = (dir.width + dir.tile_width - 1) / dir.tile_width;
+    } else {
+      // Strip-based TIFF
+      chunk_rows = dir.strip_offsets.size();
+      chunk_cols = 1;
+    }
+    
+    // Generate tile/strip keys that match our range constraints
+    for (uint32_t row = 0; row < chunk_rows; ++row) {
+      for (uint32_t col = 0; col < chunk_cols; ++col) {
+        // Create key in "tile/0/%d/%d" format
+        std::string key = absl::StrFormat("tile/0/%d/%d", row, col);
+        
+        // Check if key is in the requested range
+        if (tensorstore::Contains(options_.range, key)) {
+          // For strips, get size from strip_bytecounts
+          // For tiles, get size from tile_bytecounts
+          size_t size;
+          if (dir.tile_width > 0) {
+            size_t index = row * chunk_cols + col;
+            size = dir.tile_bytecounts[index];
+          } else {
+            size = dir.strip_bytecounts[row];
+          }
+          
+          // Strip prefix if needed
+          std::string adjusted_key = key;
+          if (options_.strip_prefix_length > 0 && 
+              options_.strip_prefix_length < key.size()) {
+            adjusted_key = key.substr(options_.strip_prefix_length);
+          }
+          
+          execution::set_value(receiver_, 
+                              ListEntry{adjusted_key, ListEntry::checked_size(size)});
+        }
+      }
+    }
+  }
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
-//  Spec::DoOpen  (now reads & validates the 8‑byte header)
+//  Spec::DoOpen
 // ─────────────────────────────────────────────────────────────────────────────
 Future<kvstore::DriverPtr> Spec::DoOpen() const {
-  // 1. Open the underlying kvstore.
-  auto base_future = kvstore::Open(data_.base);
-
-  // 2. Once base opens, issue an 8‑byte range read, validate, then build driver.
   return MapFutureValue(
       InlineExecutor{},
       [spec = internal::IntrusivePtr<const Spec>(this)](
-          kvstore::KvStore& base_kv) mutable -> Future<kvstore::DriverPtr> {
-        // ---- read first 8 bytes
-        ReadOptions hdr_opt;
-        hdr_opt.byte_range =
-            OptionalByteRangeRequest::Range(0, 8);  // header only
-        auto hdr_future =
-            base_kv.driver->Read(base_kv.path, std::move(hdr_opt));
-        
-            // ---- parse & construct driver
-        return MapFutureValue(
-            InlineExecutor{},
-            [spec, base_kv](const ReadResult& hdr_rr)
-                -> Future<kvstore::DriverPtr> {
-              TiffHeader hdr;
-              TENSORSTORE_RETURN_IF_ERROR(ParseHeader(hdr_rr.value, hdr));
+          kvstore::KvStore& base_kvstore) mutable 
+          -> Result<kvstore::DriverPtr> {
+        // Create cache key from base kvstore and executor
+        std::string cache_key;
+        internal::EncodeCacheKey(&cache_key, base_kvstore.driver,
+                               base_kvstore.path,
+                               spec->data_.data_copy_concurrency);
+                               
+        // Get or create the directory cache
+        auto& cache_pool = *spec->data_.cache_pool;
+        auto directory_cache = internal::GetCache<TiffDirectoryCache>(
+            cache_pool.get(), cache_key, [&] {
+              return std::make_unique<TiffDirectoryCache>(
+                  base_kvstore.driver,
+                  spec->data_.data_copy_concurrency->executor);
+            });
 
-              // Read 2‑byte count first
-              ReadOptions cnt_opt;
-              cnt_opt.byte_range =
-                  OptionalByteRangeRequest::Range(hdr.first_ifd_offset, hdr.first_ifd_offset+2);
-              auto cnt_future =
-                  base_kv.driver->Read(base_kv.path, cnt_opt);
-
-              return MapFutureValue(
-                  InlineExecutor{},
-                  [spec, base_kv, hdr, hdr_rr](const ReadResult& cnt_rr)
-                      -> Future<kvstore::DriverPtr> {
-                    
-                    uint16_t n_entries =
-                        Read16(std::string(cnt_rr.value).data(), hdr.endian);
-                    size_t ifd_bytes = 2 + size_t(n_entries)*12 + 4;
-
-                    ReadOptions ifd_opt;
-                    ifd_opt.byte_range = OptionalByteRangeRequest::Range(
-                        hdr.first_ifd_offset, hdr.first_ifd_offset + ifd_bytes);
-                    auto ifd_future =
-                        base_kv.driver->Read(base_kv.path, ifd_opt);
-
-                    return MapFutureValue(
-                        InlineExecutor{},
-                        [spec, base_kv, hdr, hdr_rr](const ReadResult& ifd_rr)
-                            -> Result<kvstore::DriverPtr> {
-                          ImageDirectory dir;
-                          TENSORSTORE_RETURN_IF_ERROR(
-                              ParseIfd(ifd_rr.value, 0, hdr.endian, dir));
-
-                          // Construct driver
-                          auto drv   = internal::MakeIntrusivePtr<TiffKeyValueStore>();
-                          drv->base_ = base_kv;
-                          drv->spec_data_ = spec->data_;
-                          drv->header_raw_    = hdr_rr.value;
-                          drv->header_parsed_ = hdr;
-                          drv->first_ifd_     = std::move(dir);
-                          ABSL_LOG_IF(INFO, tiff_logging) << "TIFF open: "
-                                         << drv->first_ifd_.width << "x"
-                                         << drv->first_ifd_.height
-                                         << (drv->first_ifd_.tiled?" tiled":" stripped");
-                          return kvstore::DriverPtr(drv);
-                        },
-                        ifd_future);
-                  },
-                  cnt_future);
-            },
-            std::move(hdr_future));
+        // Create the driver and set its fields
+        auto driver = internal::MakeIntrusivePtr<TiffKeyValueStore>();
+        driver->base_ = std::move(base_kvstore);
+        driver->spec_data_ = std::move(spec->data_);
+        driver->cache_entry_ =
+            GetCacheEntry(directory_cache, driver->base_.path);
+            
+        return driver;
       },
-      std::move(base_future));
+      kvstore::Open(data_.base));
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-//  GC declaration (driver holds no GC‑relevant objects)
-// ─────────────────────────────────────────────────────────────────────────────
+Future<ReadResult> TiffKeyValueStore::Read(Key key, ReadOptions options) {
+  uint32_t ifd, row, col;
+  if (auto st = ParseTileKey(key, ifd, row, col); !st.ok()) {
+    // Instead of returning the error, return a "missing" result
+    return MakeReadyFuture<ReadResult>(kvstore::ReadResult::Missing(
+        TimestampedStorageGeneration{StorageGeneration::NoValue(), absl::Now()}));
+  }
+
+  auto state = internal::MakeIntrusivePtr<ReadState>();
+  state->owner_ = internal::IntrusivePtr<TiffKeyValueStore>(this);
+  state->key_ = std::move(key);
+  state->options_ = options;
+  state->ifd_ = ifd;
+  state->row_ = row;
+  state->col_ = col;
+
+  return PromiseFuturePair<kvstore::ReadResult>::LinkValue(
+      WithExecutor(executor(),
+                   [state = std::move(state)](Promise<ReadResult> promise,
+                                              ReadyFuture<const void>) {
+                     if (!promise.result_needed()) return;
+                     state->OnDirectoryReady(std::move(promise));
+                   }),
+      cache_entry_->Read({options.staleness_bound}))
+      .future;
+}
+
+void TiffKeyValueStore::ListImpl(ListOptions options, ListReceiver receiver) {
+  auto state = internal::MakeIntrusivePtr<ListState>(
+      internal::IntrusivePtr<TiffKeyValueStore>(this), std::move(options),
+      std::move(receiver));
+  auto* state_ptr = state.get();
+
+  LinkValue(WithExecutor(executor(),
+                         [state = std::move(state)](Promise<void> promise,
+                                                  ReadyFuture<const void>) {
+                           state->OnDirectoryReady();
+                         }),
+            state_ptr->promise_,
+            cache_entry_->Read({state_ptr->options_.staleness_bound}));
+}
+
+
+}  // namespace
+
+// GetTiffKeyValueStore factory function implementation
+DriverPtr GetTiffKeyValueStore(DriverPtr base_kvstore) {
+  auto driver = internal::MakeIntrusivePtr<TiffKeyValueStore>();
+  driver->base_ = KvStore(base_kvstore);
+  driver->spec_data_.data_copy_concurrency = Context::Resource<internal::DataCopyConcurrencyResource>::DefaultSpec();
+  driver->spec_data_.cache_pool = Context::Resource<internal::CachePoolResource>::DefaultSpec();
+  
+  auto& cache_pool = *driver->spec_data_.cache_pool;
+  std::string cache_key;
+  internal::EncodeCacheKey(&cache_key, driver->base_.driver,
+                         driver->base_.path,
+                         driver->spec_data_.data_copy_concurrency);
+                         
+  auto directory_cache = internal::GetCache<TiffDirectoryCache>(
+      cache_pool.get(), cache_key, [&] {
+        return std::make_unique<TiffDirectoryCache>(
+            driver->base_.driver,
+            driver->spec_data_.data_copy_concurrency->executor);
+      });
+      
+  driver->cache_entry_ =
+      GetCacheEntry(directory_cache, driver->base_.path);
+      
+  return driver;
+}
+
 }  // namespace tensorstore::kvstore::tiff_kvstore
 
 TENSORSTORE_DECLARE_GARBAGE_COLLECTION_NOT_REQUIRED(

--- a/tensorstore/kvstore/tiff/tiff_key_value_store.cc
+++ b/tensorstore/kvstore/tiff/tiff_key_value_store.cc
@@ -1,4 +1,4 @@
-// Copyright 2024 The TensorStore Authors
+// Copyright 2025 The TensorStore Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// -----------------------------------------------------------------------------
-// TIFF key‑value‑store adapter
-//   * read‑only
-//   * uses TiffDirectoryCache for parsing TIFF file structure
-//   * supports tile or strip-based TIFF files
-// -----------------------------------------------------------------------------
-
 #include "tensorstore/kvstore/tiff/tiff_key_value_store.h"
 
 #include <memory>
@@ -30,7 +23,7 @@
 #include "absl/status/status.h"
 #include "absl/strings/cord.h"
 #include "absl/strings/str_format.h"
-#include "absl/strings/strip.h"  // For ConsumePrefix
+#include "absl/strings/strip.h"
 #include "tensorstore/context.h"
 #include "tensorstore/internal/cache/async_cache.h"
 #include "tensorstore/internal/cache/cache.h"
@@ -97,9 +90,6 @@ absl::Status ParseTileKey(std::string_view key, uint32_t& ifd, uint32_t& row,
   return absl::OkStatus();
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-//  Spec‑data (JSON parameters)
-// ─────────────────────────────────────────────────────────────────────────────
 struct TiffKvStoreSpecData {
   kvstore::Spec base;
   Context::Resource<internal::CachePoolResource> cache_pool;
@@ -119,9 +109,6 @@ struct TiffKvStoreSpecData {
           jb::Projection<&TiffKvStoreSpecData::data_copy_concurrency>()));
 };
 
-// ─────────────────────────────────────────────────────────────────────────────
-//  Spec
-// ─────────────────────────────────────────────────────────────────────────────
 struct Spec
     : public internal_kvstore::RegisteredDriverSpec<Spec, TiffKvStoreSpecData> {
   static constexpr char id[] = "tiff";
@@ -136,9 +123,6 @@ struct Spec
   }
 };
 
-// ─────────────────────────────────────────────────────────────────────────────
-//  Driver
-// ─────────────────────────────────────────────────────────────────────────────
 class TiffKeyValueStore
     : public internal_kvstore::RegisteredDriver<TiffKeyValueStore, Spec> {
  public:
@@ -410,9 +394,6 @@ struct ListState : public internal::AtomicReferenceCount<ListState> {
   }
 };
 
-// ─────────────────────────────────────────────────────────────────────────────
-//  Spec::DoOpen
-// ─────────────────────────────────────────────────────────────────────────────
 Future<kvstore::DriverPtr> Spec::DoOpen() const {
   return MapFutureValue(
       InlineExecutor{},

--- a/tensorstore/kvstore/tiff/tiff_key_value_store.h
+++ b/tensorstore/kvstore/tiff/tiff_key_value_store.h
@@ -1,0 +1,24 @@
+// tensorstore/kvstore/tiff/tiff_key_value_store.h
+//
+// Tensorstore driver for readonly tiled TIFF files.
+
+#ifndef TENSORSTORE_KVSTORE_TIFF_TIFF_KEY_VALUE_STORE_H_
+#define TENSORSTORE_KVSTORE_TIFF_TIFF_KEY_VALUE_STORE_H_
+
+#include "tensorstore/kvstore/driver.h"
+#include "tensorstore/kvstore/kvstore.h"
+
+namespace tensorstore {
+namespace kvstore {
+namespace tiff_kvstore {
+
+/// Opens a TIFF-backed KeyValueStore treating each tile as a separate key.
+/// @param base_kvstore Base kvstore (e.g., local file, GCS, HTTP-backed).
+/// @returns DriverPtr wrapping the TIFF store.
+DriverPtr GetTiffKeyValueStore(DriverPtr base_kvstore);
+
+}  // namespace tiff_kvstore
+}  // namespace kvstore
+}  // namespace tensorstore
+
+#endif  // TENSORSTORE_KVSTORE_TIFF_TIFF_KEY_VALUE_STORE_H_

--- a/tensorstore/kvstore/tiff/tiff_key_value_store.h
+++ b/tensorstore/kvstore/tiff/tiff_key_value_store.h
@@ -1,6 +1,16 @@
-// tensorstore/kvstore/tiff/tiff_key_value_store.h
+// Copyright 2025 The TensorStore Authors
 //
-// Tensorstore driver for readonly tiled TIFF files.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef TENSORSTORE_KVSTORE_TIFF_TIFF_KEY_VALUE_STORE_H_
 #define TENSORSTORE_KVSTORE_TIFF_TIFF_KEY_VALUE_STORE_H_

--- a/tensorstore/kvstore/tiff/tiff_key_value_store_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_key_value_store_test.cc
@@ -1,7 +1,16 @@
-// tensorstore/kvstore/tiff/tiff_key_value_store_test.cc
+// Copyright 2025 The TensorStore Authors
 //
-// Tests for the TIFF kv‑store adapter, patterned after
-// zip_key_value_store_test.cc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "tensorstore/kvstore/tiff/tiff_key_value_store.h"
 
@@ -44,26 +53,25 @@ class TiffKeyValueStoreTest : public ::testing::Test {
  public:
   TiffKeyValueStoreTest() : context_(Context::Default()) {}
 
-  // Writes `value` to the in‑memory store at key "data.tif".
+  // Writes `value` to the in‑memory store at key "data.tiff".
   void PrepareMemoryKvstore(absl::Cord value) {
     TENSORSTORE_ASSERT_OK_AND_ASSIGN(
         tensorstore::KvStore memory,
         kvstore::Open({{"driver", "memory"}}, context_).result());
 
-    TENSORSTORE_CHECK_OK(kvstore::Write(memory, "data.tif", value).result());
+    TENSORSTORE_CHECK_OK(kvstore::Write(memory, "data.tiff", value).result());
   }
 
   tensorstore::Context context_;
 };
 
-// ─── Tiled TIFF ──────────────────────────────────────────────────────────────
 TEST_F(TiffKeyValueStoreTest, Tiled_ReadSuccess) {
   PrepareMemoryKvstore(absl::Cord(MakeTinyTiledTiff()));
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -78,7 +86,7 @@ TEST_F(TiffKeyValueStoreTest, Tiled_OutOfRange) {
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -86,14 +94,13 @@ TEST_F(TiffKeyValueStoreTest, Tiled_OutOfRange) {
   EXPECT_THAT(status, MatchesStatus(absl::StatusCode::kOutOfRange));
 }
 
-// ─── Striped TIFF ────────────────────────────────────────────────────────────
 TEST_F(TiffKeyValueStoreTest, Striped_ReadOneStrip) {
   PrepareMemoryKvstore(absl::Cord(MakeTinyStripedTiff()));
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -108,7 +115,7 @@ TEST_F(TiffKeyValueStoreTest, Striped_ReadSecondStrip) {
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -123,7 +130,7 @@ TEST_F(TiffKeyValueStoreTest, Striped_OutOfRangeRow) {
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -131,14 +138,13 @@ TEST_F(TiffKeyValueStoreTest, Striped_OutOfRangeRow) {
   EXPECT_THAT(status, MatchesStatus(absl::StatusCode::kOutOfRange));
 }
 
-// ─── Test List Operation ───────────────────────────────────────────────────
 TEST_F(TiffKeyValueStoreTest, List) {
   PrepareMemoryKvstore(absl::Cord(MakeTinyTiledTiff()));
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -160,14 +166,13 @@ TEST_F(TiffKeyValueStoreTest, List) {
   }
 }
 
-// ─── Test List with Prefix ────────────────────────────────────────────────
 TEST_F(TiffKeyValueStoreTest, ListWithPrefix) {
   PrepareMemoryKvstore(absl::Cord(MakeTwoStripedTiff()));
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -191,14 +196,13 @@ TEST_F(TiffKeyValueStoreTest, ListWithPrefix) {
   }
 }
 
-// ─── Test multiple strips list ────────────────────────────────────────────
 TEST_F(TiffKeyValueStoreTest, ListMultipleStrips) {
   PrepareMemoryKvstore(absl::Cord(MakeTwoStripedTiff()));
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -217,7 +221,6 @@ TEST_F(TiffKeyValueStoreTest, ListMultipleStrips) {
                        "set_value: tile/0/1/0", "set_done", "set_stopping"));
 }
 
-// ─── Test ReadOps ──────────────────────────────────────────────────────────
 TEST_F(TiffKeyValueStoreTest, ReadOps) {
   PrepareMemoryKvstore(absl::Cord(MakeReadOpTiff()));
 
@@ -225,7 +228,7 @@ TEST_F(TiffKeyValueStoreTest, ReadOps) {
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -234,7 +237,6 @@ TEST_F(TiffKeyValueStoreTest, ReadOps) {
       store, "tile/0/0/0", absl::Cord("abcdefghijklmnop"), "missing_key");
 }
 
-// ─── Test invalid specs ─────────────────────────────────────────────────────
 TEST_F(TiffKeyValueStoreTest, InvalidSpec) {
   auto context = tensorstore::Context::Default();
 
@@ -244,7 +246,6 @@ TEST_F(TiffKeyValueStoreTest, InvalidSpec) {
       MatchesStatus(absl::StatusCode::kInvalidArgument));
 }
 
-// ─── Test spec roundtrip ────────────────────────────────────────────────────
 TEST_F(TiffKeyValueStoreTest, SpecRoundtrip) {
   tensorstore::internal::KeyValueStoreSpecRoundtripOptions options;
   options.check_data_persists = false;
@@ -263,7 +264,7 @@ TEST_F(TiffKeyValueStoreTest, MalformedTiff) {
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -271,14 +272,13 @@ TEST_F(TiffKeyValueStoreTest, MalformedTiff) {
   EXPECT_FALSE(status.ok());
 }
 
-// 1. Test Invalid Key Formats
 TEST_F(TiffKeyValueStoreTest, InvalidKeyFormats) {
   PrepareMemoryKvstore(absl::Cord(MakeTinyTiledTiff()));
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -301,14 +301,13 @@ TEST_F(TiffKeyValueStoreTest, InvalidKeyFormats) {
   EXPECT_THAT(test_key("tile/0/0/0/extra"), MatchesKvsReadResultNotFound());
 }
 
-// 2. Test Multiple IFDs
 TEST_F(TiffKeyValueStoreTest, MultipleIFDs) {
   PrepareMemoryKvstore(absl::Cord(MakeMultiIfdTiff()));
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -327,14 +326,13 @@ TEST_F(TiffKeyValueStoreTest, MultipleIFDs) {
   EXPECT_THAT(status, MatchesStatus(absl::StatusCode::kNotFound));
 }
 
-// 3. Test Byte Range Reads
 TEST_F(TiffKeyValueStoreTest, ByteRangeReads) {
   PrepareMemoryKvstore(absl::Cord(MakeReadOpTiff()));
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -367,14 +365,13 @@ TEST_F(TiffKeyValueStoreTest, ByteRangeReads) {
   EXPECT_FALSE(status.ok());
 }
 
-// 4. Test Missing Required Tags
 TEST_F(TiffKeyValueStoreTest, MissingRequiredTags) {
   PrepareMemoryKvstore(absl::Cord(MakeTiffMissingHeight()));
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -389,7 +386,7 @@ TEST_F(TiffKeyValueStoreTest, StalenessBound) {
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 
@@ -406,14 +403,13 @@ TEST_F(TiffKeyValueStoreTest, StalenessBound) {
               ::tensorstore::IsOk());
 }
 
-// 6. Test List with Range Constraints
 TEST_F(TiffKeyValueStoreTest, ListWithComplexRange) {
   PrepareMemoryKvstore(absl::Cord(MakeTwoStripedTiff()));
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
       kvstore::Open({{"driver", "tiff"},
-                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                     {"base", {{"driver", "memory"}, {"path", "data.tiff"}}}},
                     context_)
           .result());
 

--- a/tensorstore/kvstore/tiff/tiff_key_value_store_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_key_value_store_test.cc
@@ -1,0 +1,264 @@
+// tensorstore/kvstore/tiff/tiff_key_value_store_test.cc
+//
+// Tests for the TIFF kv‑store adapter, patterned after
+// zip_key_value_store_test.cc.
+
+#include "tensorstore/kvstore/tiff/tiff_key_value_store.h"
+
+#include <string>
+
+#include "absl/strings/cord.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "tensorstore/context.h"
+#include "tensorstore/kvstore/kvstore.h"
+#include "tensorstore/kvstore/operations.h"
+#include "tensorstore/kvstore/spec.h"
+#include "tensorstore/util/status_testutil.h"
+
+namespace {
+
+namespace kvstore = tensorstore::kvstore;
+using ::tensorstore::Context;
+using ::tensorstore::MatchesStatus;
+
+/* -------------------------------------------------------------------------- */
+/*                       Little‑endian byte helpers                           */
+/* -------------------------------------------------------------------------- */
+void PutLE16(std::string& dst, uint16_t v) {
+  dst.push_back(static_cast<char>(v & 0xff));
+  dst.push_back(static_cast<char>(v >> 8));
+}
+void PutLE32(std::string& dst, uint32_t v) {
+  dst.push_back(static_cast<char>(v & 0xff));
+  dst.push_back(static_cast<char>(v >> 8));
+  dst.push_back(static_cast<char>(v >> 16));
+  dst.push_back(static_cast<char>(v >> 24));
+}
+
+/* -------------------------------------------------------------------------- */
+/*                     Minimal TIFF byte‑string builders                      */
+/* -------------------------------------------------------------------------- */
+
+// 512 × 512 image, one 256 × 256 tile at offset 128, payload “DATA”.
+std::string MakeTinyTiledTiff() {
+  std::string t;
+  t += "II"; PutLE16(t, 42); PutLE32(t, 8);     // header
+
+  PutLE16(t, 6);                                // 6 IFD entries
+  auto E=[&](uint16_t tag,uint16_t type,uint32_t cnt,uint32_t val){
+    PutLE16(t,tag); PutLE16(t,type); PutLE32(t,cnt); PutLE32(t,val);};
+  E(256,3,1,512); E(257,3,1,512);               // width, length
+  E(322,3,1,256); E(323,3,1,256);               // tile width/length
+  E(324,4,1,128); E(325,4,1,4);                 // offset/bytecount
+  PutLE32(t,0);                                 // next IFD
+
+  if (t.size() < 128) t.resize(128,'\0');
+  t += "DATA";
+  return t;
+}
+
+std::string MakeTinyStripedTiff() {
+  std::string t;
+
+  // TIFF header
+  t += "II"; PutLE16(t, 42); PutLE32(t, 8);
+
+  // IFD
+  PutLE16(t, 5);  // 5 IFD entries
+  auto E=[&](uint16_t tag,uint16_t type,uint32_t cnt,uint32_t val){
+    PutLE16(t,tag); PutLE16(t,type); PutLE32(t,cnt); PutLE32(t,val);};
+
+  // entries
+  E(256, 3, 1, 4);    // ImageWidth = 4
+  E(257, 3, 1, 8);    // ImageLength = 8
+  E(278, 3, 1, 8);    // RowsPerStrip = 8  (entire image = 1 strip)
+  E(273, 4, 1, 128);  // StripOffsets = 128 (pointing to the data)
+  E(279, 4, 1, 8);    // StripByteCounts = 8 bytes (DATASTR)
+  PutLE32(t, 0);      // next IFD = 0 (no more IFDs)
+
+  // Add padding up to offset 128
+  if (t.size() < 128) t.resize(128, '\0');
+
+  // The actual strip data (8 bytes)
+  t += "DATASTR!";  // Example: 8 bytes of data
+
+  return t;
+}
+
+std::string MakeTwoStripedTiff() {
+  std::string t;
+
+  // ─── Header: II + magic 42 + IFD at byte 8
+  t += "II";
+  PutLE16(t, 42);    // magic
+  PutLE32(t, 8);     // first IFD offset
+
+  // ─── IFD entry count = 6
+  PutLE16(t, 6);
+
+  // Helper: write one entry
+  auto E = [&](uint16_t tag, uint16_t type, uint32_t count, uint32_t value) {
+    PutLE16(t, tag);
+    PutLE16(t, type);
+    PutLE32(t, count);
+    PutLE32(t, value);
+  };
+
+  // 1) ImageWidth=4, 2) ImageLength=8
+  E(256, 3, 1, 4);  // SHORT=3
+  E(257, 3, 1, 8);  // SHORT=3
+
+  // 3) RowsPerStrip=4 => 2 total strips
+  E(278, 3, 1, 4);
+
+  // 4) StripOffsets array => 2 LONG => at offset 128
+  E(273, 4, 2, 128);
+
+  // 5) StripByteCounts => 2 LONG => at offset 136
+  E(279, 4, 2, 136);
+
+  // 6) Compression => none=1
+  E(259, 3, 1, 1);
+
+  // next‑IFD offset = 0
+  PutLE32(t, 0);
+
+  // ─── Arrive at offset 128
+  if (t.size() < 128) t.resize(128, '\0');
+
+  // two 4‑byte offsets in array => total 8 bytes
+  // let’s say strip #0 data at offset=200, strip #1 at offset=208
+  PutLE32(t, 200);  // 1st strip offset
+  PutLE32(t, 208);  // 2nd strip offset
+
+  // ─── Arrive at offset 136
+  if (t.size() < 136) t.resize(136, '\0');
+
+  // two 4‑byte bytecounts => total 8 bytes
+  // each strip = 4
+  PutLE32(t, 4); // strip #0 size
+  PutLE32(t, 4); // strip #1 size
+
+  // ─── Pad to 200, then write "AAAA"
+  if (t.size() < 200) t.resize(200, '\0');
+  t.replace(200, 4, "AAAA");
+
+  // ─── Pad to 208, then write "BBBB"
+  if (t.size() < 208) t.resize(208, '\0');
+  t.replace(208, 4, "BBBB");
+
+  return t;
+}
+
+
+/* -------------------------------------------------------------------------- */
+/*                            Test‑fixture class                              */
+/* -------------------------------------------------------------------------- */
+
+class TiffKeyValueStoreTest : public ::testing::Test {
+ public:
+  TiffKeyValueStoreTest() : context_(Context::Default()) {}
+
+  // Writes `value` to the in‑memory store at key "data.tif".
+  void PrepareMemoryKvstore(absl::Cord value) {
+    TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+        tensorstore::KvStore memory,
+        kvstore::Open({{"driver", "memory"}}, context_).result());
+
+    TENSORSTORE_CHECK_OK(
+        kvstore::Write(memory, "data.tif", value).result());
+  }
+
+  tensorstore::Context context_;
+};
+
+/* -------------------------------------------------------------------------- */
+/*                                 Tests                                      */
+/* -------------------------------------------------------------------------- */
+
+// ─── Tiled TIFF ──────────────────────────────────────────────────────────────
+TEST_F(TiffKeyValueStoreTest, Tiled_ReadSuccess) {
+  PrepareMemoryKvstore(absl::Cord(MakeTinyTiledTiff()));
+
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      auto tiff_store,
+      kvstore::Open({{"driver","tiff"},
+                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
+                    context_).result());
+
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      auto rr, kvstore::Read(tiff_store,"tile/0/0/0").result());
+  EXPECT_EQ(std::string(rr.value), "DATA");
+}
+
+TEST_F(TiffKeyValueStoreTest, Tiled_OutOfRange) {
+  PrepareMemoryKvstore(absl::Cord(MakeTinyTiledTiff()));
+
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      auto tiff_store,
+      kvstore::Open({{"driver","tiff"},
+                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
+                    context_).result());
+
+  auto status = kvstore::Read(tiff_store,"tile/0/9/9").result().status();
+  EXPECT_THAT(status, MatchesStatus(absl::StatusCode::kOutOfRange));
+}
+
+// ─── Striped TIFF ────────────────────────────────────────────────────────────
+TEST_F(TiffKeyValueStoreTest, Striped_ReadOneStrip) {
+  PrepareMemoryKvstore(absl::Cord(MakeTinyStripedTiff()));
+
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      auto tiff_store,
+      kvstore::Open({{"driver","tiff"},
+                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
+                    context_).result());
+
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      auto rr, kvstore::Read(tiff_store,"tile/0/0/0").result());
+  EXPECT_EQ(std::string(rr.value), "DATASTR!");
+}
+
+TEST_F(TiffKeyValueStoreTest, Striped_ReadSecondStrip) {
+  PrepareMemoryKvstore(absl::Cord(MakeTwoStripedTiff()));
+
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      auto tiff_store,
+      kvstore::Open({{"driver","tiff"},
+                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
+                    context_).result());
+
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      auto rr, kvstore::Read(tiff_store,"tile/0/1/0").result());
+  EXPECT_EQ(std::string(rr.value), "BBBB");
+}
+
+TEST_F(TiffKeyValueStoreTest, Striped_OutOfRangeRow) {
+  PrepareMemoryKvstore(absl::Cord(MakeTinyStripedTiff()));
+
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      auto tiff_store,
+      kvstore::Open({{"driver","tiff"},
+                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
+                    context_).result());
+
+  auto status = kvstore::Read(tiff_store,"tile/0/2/0").result().status();
+  EXPECT_THAT(status, MatchesStatus(absl::StatusCode::kOutOfRange));
+}
+
+// ─── Bad key format ─────────────────────────────────────────────────────────
+TEST_F(TiffKeyValueStoreTest, BadKeyFormat) {
+  PrepareMemoryKvstore(absl::Cord(MakeTinyTiledTiff()));
+
+  TENSORSTORE_ASSERT_OK_AND_ASSIGN(
+      auto tiff_store,
+      kvstore::Open({{"driver","tiff"},
+                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
+                    context_).result());
+
+  auto status = kvstore::Read(tiff_store,"foo/bar").result().status();
+  EXPECT_THAT(status, MatchesStatus(absl::StatusCode::kInvalidArgument));
+}
+
+}  // namespace

--- a/tensorstore/kvstore/tiff/tiff_key_value_store_test.cc
+++ b/tensorstore/kvstore/tiff/tiff_key_value_store_test.cc
@@ -8,30 +8,28 @@
 #include <string>
 
 #include "absl/strings/cord.h"
+#include "absl/synchronization/notification.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "tensorstore/context.h"
+#include "tensorstore/kvstore/byte_range.h"
+#include "tensorstore/kvstore/key_range.h"
 #include "tensorstore/kvstore/kvstore.h"
 #include "tensorstore/kvstore/operations.h"
 #include "tensorstore/kvstore/spec.h"
-#include "tensorstore/kvstore/test_util.h"
-#include "tensorstore/kvstore/byte_range.h"
-#include "tensorstore/kvstore/key_range.h"
 #include "tensorstore/kvstore/test_matchers.h"
-#include "tensorstore/util/status_testutil.h"
-#include "absl/synchronization/notification.h"
+#include "tensorstore/kvstore/test_util.h"
 #include "tensorstore/util/execution/sender_testutil.h"
-
+#include "tensorstore/util/status_testutil.h"
 
 namespace {
 
 namespace kvstore = tensorstore::kvstore;
-using ::tensorstore::Context;
-using ::tensorstore::MatchesStatus;
 using ::tensorstore::CompletionNotifyingReceiver;
-using ::tensorstore::internal::MatchesKvsReadResultNotFound;
+using ::tensorstore::Context;
 using ::tensorstore::KeyRange;
-
+using ::tensorstore::MatchesStatus;
+using ::tensorstore::internal::MatchesKvsReadResultNotFound;
 
 /* -------------------------------------------------------------------------- */
 /*                       Little‑endian byte helpers                           */
@@ -54,17 +52,26 @@ void PutLE32(std::string& dst, uint32_t v) {
 // 256 × 256 image, one 256 × 256 tile at offset 128, payload "DATA".
 std::string MakeTinyTiledTiff() {
   std::string t;
-  t += "II"; PutLE16(t, 42); PutLE32(t, 8);     // header
+  t += "II";
+  PutLE16(t, 42);
+  PutLE32(t, 8);  // header
 
-  PutLE16(t, 6);                                // 6 IFD entries
-  auto E=[&](uint16_t tag,uint16_t type,uint32_t cnt,uint32_t val){
-    PutLE16(t,tag); PutLE16(t,type); PutLE32(t,cnt); PutLE32(t,val);};
-  E(256,3,1,256); E(257,3,1,256);               // width, length (256×256 instead of 512×512)
-  E(322,3,1,256); E(323,3,1,256);               // tile width/length
-  E(324,4,1,128); E(325,4,1,4);                 // offset/bytecount
-  PutLE32(t,0);                                 // next IFD
+  PutLE16(t, 6);  // 6 IFD entries
+  auto E = [&](uint16_t tag, uint16_t type, uint32_t cnt, uint32_t val) {
+    PutLE16(t, tag);
+    PutLE16(t, type);
+    PutLE32(t, cnt);
+    PutLE32(t, val);
+  };
+  E(256, 3, 1, 256);
+  E(257, 3, 1, 256);  // width, length (256×256 instead of 512×512)
+  E(322, 3, 1, 256);
+  E(323, 3, 1, 256);  // tile width/length
+  E(324, 4, 1, 128);
+  E(325, 4, 1, 4);  // offset/bytecount
+  PutLE32(t, 0);    // next IFD
 
-  if (t.size() < 128) t.resize(128,'\0');
+  if (t.size() < 128) t.resize(128, '\0');
   t += "DATA";
   return t;
 }
@@ -73,12 +80,18 @@ std::string MakeTinyStripedTiff() {
   std::string t;
 
   // TIFF header
-  t += "II"; PutLE16(t, 42); PutLE32(t, 8);
+  t += "II";
+  PutLE16(t, 42);
+  PutLE32(t, 8);
 
   // IFD
   PutLE16(t, 5);  // 5 IFD entries
-  auto E=[&](uint16_t tag,uint16_t type,uint32_t cnt,uint32_t val){
-    PutLE16(t,tag); PutLE16(t,type); PutLE32(t,cnt); PutLE32(t,val);};
+  auto E = [&](uint16_t tag, uint16_t type, uint32_t cnt, uint32_t val) {
+    PutLE16(t, tag);
+    PutLE16(t, type);
+    PutLE32(t, cnt);
+    PutLE32(t, val);
+  };
 
   // entries
   E(256, 3, 1, 4);    // ImageWidth = 4
@@ -102,8 +115,8 @@ std::string MakeTwoStripedTiff() {
 
   // ─── Header: II + magic 42 + IFD at byte 8
   t += "II";
-  PutLE16(t, 42);    // magic
-  PutLE32(t, 8);     // first IFD offset
+  PutLE16(t, 42);  // magic
+  PutLE32(t, 8);   // first IFD offset
 
   // ─── IFD entry count = 6
   PutLE16(t, 6);
@@ -148,8 +161,8 @@ std::string MakeTwoStripedTiff() {
 
   // two 4‑byte bytecounts => total 8 bytes
   // each strip = 4
-  PutLE32(t, 4); // strip #0 size
-  PutLE32(t, 4); // strip #1 size
+  PutLE32(t, 4);  // strip #0 size
+  PutLE32(t, 4);  // strip #1 size
 
   // ─── Pad to 200, then write "AAAA"
   if (t.size() < 200) t.resize(200, '\0');
@@ -161,7 +174,6 @@ std::string MakeTwoStripedTiff() {
 
   return t;
 }
-
 
 /* -------------------------------------------------------------------------- */
 /*                            Test‑fixture class                              */
@@ -177,8 +189,7 @@ class TiffKeyValueStoreTest : public ::testing::Test {
         tensorstore::KvStore memory,
         kvstore::Open({{"driver", "memory"}}, context_).result());
 
-    TENSORSTORE_CHECK_OK(
-        kvstore::Write(memory, "data.tif", value).result());
+    TENSORSTORE_CHECK_OK(kvstore::Write(memory, "data.tif", value).result());
   }
 
   tensorstore::Context context_;
@@ -194,12 +205,13 @@ TEST_F(TiffKeyValueStoreTest, Tiled_ReadSuccess) {
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
-      auto rr, kvstore::Read(tiff_store,"tile/0/0/0").result());
+      auto rr, kvstore::Read(tiff_store, "tile/0/0/0").result());
   EXPECT_EQ(std::string(rr.value), "DATA");
 }
 
@@ -208,11 +220,12 @@ TEST_F(TiffKeyValueStoreTest, Tiled_OutOfRange) {
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
-  auto status = kvstore::Read(tiff_store,"tile/0/9/9").result().status();
+  auto status = kvstore::Read(tiff_store, "tile/0/9/9").result().status();
   EXPECT_THAT(status, MatchesStatus(absl::StatusCode::kOutOfRange));
 }
 
@@ -222,12 +235,13 @@ TEST_F(TiffKeyValueStoreTest, Striped_ReadOneStrip) {
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
-      auto rr, kvstore::Read(tiff_store,"tile/0/0/0").result());
+      auto rr, kvstore::Read(tiff_store, "tile/0/0/0").result());
   EXPECT_EQ(std::string(rr.value), "DATASTR!");
 }
 
@@ -236,12 +250,13 @@ TEST_F(TiffKeyValueStoreTest, Striped_ReadSecondStrip) {
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
-      auto rr, kvstore::Read(tiff_store,"tile/0/1/0").result());
+      auto rr, kvstore::Read(tiff_store, "tile/0/1/0").result());
   EXPECT_EQ(std::string(rr.value), "BBBB");
 }
 
@@ -250,11 +265,12 @@ TEST_F(TiffKeyValueStoreTest, Striped_OutOfRangeRow) {
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
-  auto status = kvstore::Read(tiff_store,"tile/0/2/0").result().status();
+  auto status = kvstore::Read(tiff_store, "tile/0/2/0").result().status();
   EXPECT_THAT(status, MatchesStatus(absl::StatusCode::kOutOfRange));
 }
 
@@ -264,9 +280,10 @@ TEST_F(TiffKeyValueStoreTest, List) {
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
   // Listing the entire stream works.
   for (int i = 0; i < 2; ++i) {
@@ -280,8 +297,8 @@ TEST_F(TiffKeyValueStoreTest, List) {
 
     // Only one tile in our tiny tiled TIFF
     EXPECT_THAT(log, ::testing::UnorderedElementsAre(
-                         "set_starting", "set_value: tile/0/0/0",
-                         "set_done", "set_stopping"))
+                         "set_starting", "set_value: tile/0/0/0", "set_done",
+                         "set_stopping"))
         << i;
   }
 }
@@ -292,9 +309,10 @@ TEST_F(TiffKeyValueStoreTest, ListWithPrefix) {
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
   // Listing with prefix
   {
@@ -310,9 +328,9 @@ TEST_F(TiffKeyValueStoreTest, ListWithPrefix) {
     notification.WaitForNotification();
 
     // Should only show the second strip
-    EXPECT_THAT(log, ::testing::UnorderedElementsAre(
-                        "set_starting", "set_value: 0/1/0", 
-                        "set_done", "set_stopping"));
+    EXPECT_THAT(
+        log, ::testing::UnorderedElementsAre("set_starting", "set_value: 0/1/0",
+                                             "set_done", "set_stopping"));
   }
 }
 
@@ -322,9 +340,10 @@ TEST_F(TiffKeyValueStoreTest, ListMultipleStrips) {
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
   // List all strips
   absl::Notification notification;
@@ -337,27 +356,33 @@ TEST_F(TiffKeyValueStoreTest, ListMultipleStrips) {
 
   // Should show both strips
   EXPECT_THAT(log, ::testing::UnorderedElementsAre(
-                      "set_starting", 
-                      "set_value: tile/0/0/0", 
-                      "set_value: tile/0/1/0",
-                      "set_done", 
-                      "set_stopping"));
+                       "set_starting", "set_value: tile/0/0/0",
+                       "set_value: tile/0/1/0", "set_done", "set_stopping"));
 }
 
 // ─── Create minimal TIFF data for ReadOp tests ────────────────────────────
 std::string MakeReadOpTiff() {
   std::string t;
-  t += "II"; PutLE16(t, 42); PutLE32(t, 8);     // header
+  t += "II";
+  PutLE16(t, 42);
+  PutLE32(t, 8);  // header
 
-  PutLE16(t, 6);                                // 6 IFD entries
-  auto E=[&](uint16_t tag,uint16_t type,uint32_t cnt,uint32_t val){
-    PutLE16(t,tag); PutLE16(t,type); PutLE32(t,cnt); PutLE32(t,val);};
-  E(256,3,1,16); E(257,3,1,16);                // width, length
-  E(322,3,1,16); E(323,3,1,16);                // tile width/length
-  E(324,4,1,128); E(325,4,1,16);               // offset/bytecount
-  PutLE32(t,0);                                 // next IFD
+  PutLE16(t, 6);  // 6 IFD entries
+  auto E = [&](uint16_t tag, uint16_t type, uint32_t cnt, uint32_t val) {
+    PutLE16(t, tag);
+    PutLE16(t, type);
+    PutLE32(t, cnt);
+    PutLE32(t, val);
+  };
+  E(256, 3, 1, 16);
+  E(257, 3, 1, 16);  // width, length
+  E(322, 3, 1, 16);
+  E(323, 3, 1, 16);  // tile width/length
+  E(324, 4, 1, 128);
+  E(325, 4, 1, 16);  // offset/bytecount
+  PutLE32(t, 0);     // next IFD
 
-  if (t.size() < 128) t.resize(128,'\0');
+  if (t.size() < 128) t.resize(128, '\0');
   t += "abcdefghijklmnop";
   return t;
 }
@@ -402,60 +427,84 @@ TEST_F(TiffKeyValueStoreTest, SpecRoundtrip) {
   tensorstore::internal::TestKeyValueStoreSpecRoundtrip(options);
 }
 
-// ─── Test with malformed TIFF ─────────────────────────────────────────────────
+// ─── Test with malformed TIFF
+// ─────────────────────────────────────────────────
 std::string MakeMalformedTiff() {
   std::string t;
-  t += "MM"; // Bad endianness (motorola instead of intel)
-  PutLE16(t, 42); PutLE32(t, 8);     // header
-  PutLE16(t, 1);                      // 1 IFD entry
-  auto E=[&](uint16_t tag,uint16_t type,uint32_t cnt,uint32_t val){
-    PutLE16(t,tag); PutLE16(t,type); PutLE32(t,cnt); PutLE32(t,val);};
-  E(256,3,1,16);                     // Only width, missing other required tags
-  PutLE32(t,0);                      // next IFD
+  t += "MM";  // Bad endianness (motorola instead of intel)
+  PutLE16(t, 42);
+  PutLE32(t, 8);  // header
+  PutLE16(t, 1);  // 1 IFD entry
+  auto E = [&](uint16_t tag, uint16_t type, uint32_t cnt, uint32_t val) {
+    PutLE16(t, tag);
+    PutLE16(t, type);
+    PutLE32(t, cnt);
+    PutLE32(t, val);
+  };
+  E(256, 3, 1, 16);  // Only width, missing other required tags
+  PutLE32(t, 0);     // next IFD
   return t;
 }
 
 // Create a TIFF with multiple Image File Directories (IFDs)
 std::string MakeMultiIfdTiff() {
   std::string t;
-  t += "II"; PutLE16(t, 42); PutLE32(t, 8);     // header
+  t += "II";
+  PutLE16(t, 42);
+  PutLE32(t, 8);  // header
 
   // First IFD - starts at offset 8
-  PutLE16(t, 6);                                // 6 IFD entries
-  auto E=[&](uint16_t tag,uint16_t type,uint32_t cnt,uint32_t val){
-    PutLE16(t,tag); PutLE16(t,type); PutLE32(t,cnt); PutLE32(t,val);};
-  E(256,3,1,256); E(257,3,1,256);               // width, length (256×256)
-  E(322,3,1,256); E(323,3,1,256);               // tile width/length
-  E(324,4,1,200); E(325,4,1,5);                 // offset/bytecount for IFD 0
-  PutLE32(t,86);                                // next IFD offset = 72
+  PutLE16(t, 6);  // 6 IFD entries
+  auto E = [&](uint16_t tag, uint16_t type, uint32_t cnt, uint32_t val) {
+    PutLE16(t, tag);
+    PutLE16(t, type);
+    PutLE32(t, cnt);
+    PutLE32(t, val);
+  };
+  E(256, 3, 1, 256);
+  E(257, 3, 1, 256);  // width, length (256×256)
+  E(322, 3, 1, 256);
+  E(323, 3, 1, 256);  // tile width/length
+  E(324, 4, 1, 200);
+  E(325, 4, 1, 5);  // offset/bytecount for IFD 0
+  PutLE32(t, 86);   // next IFD offset = 72
 
   // Second IFD - starts at offset 86
-  PutLE16(t, 6);                                // 6 IFD entries
-  E(256,3,1,128); E(257,3,1,128);               // width, length (128×128)
-  E(322,3,1,128); E(323,3,1,128);               // tile width/length
-  E(324,4,1,208); E(325,4,1,5);                 // offset/bytecount for IFD 1
-  PutLE32(t,0);                                 // next IFD = 0 (end of IFDs)
+  PutLE16(t, 6);  // 6 IFD entries
+  E(256, 3, 1, 128);
+  E(257, 3, 1, 128);  // width, length (128×128)
+  E(322, 3, 1, 128);
+  E(323, 3, 1, 128);  // tile width/length
+  E(324, 4, 1, 208);
+  E(325, 4, 1, 5);  // offset/bytecount for IFD 1
+  PutLE32(t, 0);    // next IFD = 0 (end of IFDs)
 
   // Pad to offset 200, then add first tile data
-  if (t.size() < 200) t.resize(200,'\0');
+  if (t.size() < 200) t.resize(200, '\0');
   t += "DATA1";
 
   // Pad to offset 208, then add second tile data
-  if (t.size() < 208) t.resize(208,'\0');
+  if (t.size() < 208) t.resize(208, '\0');
   t += "DATA2";
-  
+
   return t;
 }
 
 // Creates a TIFF file missing the required ImageLength tag
 std::string MakeTiffMissingHeight() {
   std::string t;
-  t += "II"; PutLE16(t, 42); PutLE32(t, 8);     // header
-  PutLE16(t, 1);                                // 1 IFD entry
-  auto E=[&](uint16_t tag,uint16_t type,uint32_t cnt,uint32_t val){
-    PutLE16(t,tag); PutLE16(t,type); PutLE32(t,cnt); PutLE32(t,val);};
-  E(256,3,1,16);                               // Width but no Height
-  PutLE32(t,0);                                // next IFD
+  t += "II";
+  PutLE16(t, 42);
+  PutLE32(t, 8);  // header
+  PutLE16(t, 1);  // 1 IFD entry
+  auto E = [&](uint16_t tag, uint16_t type, uint32_t cnt, uint32_t val) {
+    PutLE16(t, tag);
+    PutLE16(t, type);
+    PutLE32(t, cnt);
+    PutLE32(t, val);
+  };
+  E(256, 3, 1, 16);  // Width but no Height
+  PutLE32(t, 0);     // next IFD
   return t;
 }
 
@@ -464,39 +513,41 @@ TEST_F(TiffKeyValueStoreTest, MalformedTiff) {
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
-  auto status = kvstore::Read(tiff_store,"tile/0/0/0").result().status();
+  auto status = kvstore::Read(tiff_store, "tile/0/0/0").result().status();
   EXPECT_FALSE(status.ok());
 }
 
 // 1. Test Invalid Key Formats
 TEST_F(TiffKeyValueStoreTest, InvalidKeyFormats) {
   PrepareMemoryKvstore(absl::Cord(MakeTinyTiledTiff()));
-  
+
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
   // Test various invalid key formats
   auto test_key = [&](std::string key) {
     return kvstore::Read(tiff_store, key).result();
   };
-  
+
   // Wrong prefix
   EXPECT_THAT(test_key("wrong/0/0/0"), MatchesKvsReadResultNotFound());
 
   // Missing components
   EXPECT_THAT(test_key("tile/0"), MatchesKvsReadResultNotFound());
   EXPECT_THAT(test_key("tile/0/0"), MatchesKvsReadResultNotFound());
-  
+
   // Non-numeric components
   EXPECT_THAT(test_key("tile/a/0/0"), MatchesKvsReadResultNotFound());
-  
+
   // Extra components
   EXPECT_THAT(test_key("tile/0/0/0/extra"), MatchesKvsReadResultNotFound());
 }
@@ -504,61 +555,66 @@ TEST_F(TiffKeyValueStoreTest, InvalidKeyFormats) {
 // 2. Test Multiple IFDs
 TEST_F(TiffKeyValueStoreTest, MultipleIFDs) {
   PrepareMemoryKvstore(absl::Cord(MakeMultiIfdTiff()));
-  
+
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
   // Read from the first IFD
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
-      auto rr1, kvstore::Read(tiff_store,"tile/0/0/0").result());
+      auto rr1, kvstore::Read(tiff_store, "tile/0/0/0").result());
   EXPECT_EQ(std::string(rr1.value), "DATA1");
-  
+
   // Read from the second IFD
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
-      auto rr2, kvstore::Read(tiff_store,"tile/1/0/0").result());
+      auto rr2, kvstore::Read(tiff_store, "tile/1/0/0").result());
   EXPECT_EQ(std::string(rr2.value), "DATA2");
-  
+
   // Test invalid IFD index
-  auto status = kvstore::Read(tiff_store,"tile/2/0/0").result().status();
+  auto status = kvstore::Read(tiff_store, "tile/2/0/0").result().status();
   EXPECT_THAT(status, MatchesStatus(absl::StatusCode::kNotFound));
 }
 
 // 3. Test Byte Range Reads
 TEST_F(TiffKeyValueStoreTest, ByteRangeReads) {
   PrepareMemoryKvstore(absl::Cord(MakeReadOpTiff()));
-  
+
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
-                    
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
+
   // Full read for reference
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
-      auto full_read, kvstore::Read(tiff_store,"tile/0/0/0").result());
+      auto full_read, kvstore::Read(tiff_store, "tile/0/0/0").result());
   EXPECT_EQ(std::string(full_read.value), "abcdefghijklmnop");
-  
+
   // Partial read - first half
   kvstore::ReadOptions options1;
   options1.byte_range = tensorstore::OptionalByteRangeRequest::Range(0, 8);
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
-      auto partial1, kvstore::Read(tiff_store,"tile/0/0/0", options1).result());
+      auto partial1,
+      kvstore::Read(tiff_store, "tile/0/0/0", options1).result());
   EXPECT_EQ(std::string(partial1.value), "abcdefgh");
-  
+
   // Partial read - second half
   kvstore::ReadOptions options2;
   options2.byte_range = tensorstore::OptionalByteRangeRequest::Range(8, 16);
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
-      auto partial2, kvstore::Read(tiff_store,"tile/0/0/0", options2).result());
+      auto partial2,
+      kvstore::Read(tiff_store, "tile/0/0/0", options2).result());
   EXPECT_EQ(std::string(partial2.value), "ijklmnop");
-  
+
   // Out-of-range byte range
   kvstore::ReadOptions options3;
   options3.byte_range = tensorstore::OptionalByteRangeRequest::Range(0, 20);
-  auto status = kvstore::Read(tiff_store,"tile/0/0/0", options3).result().status();
+  auto status =
+      kvstore::Read(tiff_store, "tile/0/0/0", options3).result().status();
   EXPECT_FALSE(status.ok());
 }
 
@@ -568,30 +624,32 @@ TEST_F(TiffKeyValueStoreTest, MissingRequiredTags) {
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
-  auto status = kvstore::Read(tiff_store,"tile/0/0/0").result().status();
+  auto status = kvstore::Read(tiff_store, "tile/0/0/0").result().status();
   EXPECT_FALSE(status.ok());
 }
 
 // 5. Test Staleness Bound
 TEST_F(TiffKeyValueStoreTest, StalenessBound) {
   PrepareMemoryKvstore(absl::Cord(MakeTinyTiledTiff()));
-  
+
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
   // Read with infinite past staleness bound (should work)
   kvstore::ReadOptions options_past;
   options_past.staleness_bound = absl::InfinitePast();
   EXPECT_THAT(kvstore::Read(tiff_store, "tile/0/0/0", options_past).result(),
               ::tensorstore::IsOk());
-              
+
   // Read with infinite future staleness bound (should work)
   kvstore::ReadOptions options_future;
   options_future.staleness_bound = absl::InfiniteFuture();
@@ -605,15 +663,17 @@ TEST_F(TiffKeyValueStoreTest, ListWithComplexRange) {
 
   TENSORSTORE_ASSERT_OK_AND_ASSIGN(
       auto tiff_store,
-      kvstore::Open({{"driver","tiff"},
-                     {"base",{{"driver","memory"},{"path","data.tif"}}}},
-                    context_).result());
+      kvstore::Open({{"driver", "tiff"},
+                     {"base", {{"driver", "memory"}, {"path", "data.tif"}}}},
+                    context_)
+          .result());
 
   // Test listing with exclusive range
   kvstore::ListOptions options;
-  // Fix: Use KeyRange constructor directly with the successor of the first key to create an exclusive lower bound
+  // Fix: Use KeyRange constructor directly with the successor of the first key
+  // to create an exclusive lower bound
   options.range = KeyRange(KeyRange::Successor("tile/0/0/0"), "tile/0/2/0");
-  
+
   absl::Notification notification;
   std::vector<std::string> log;
   tensorstore::execution::submit(
@@ -623,11 +683,9 @@ TEST_F(TiffKeyValueStoreTest, ListWithComplexRange) {
   notification.WaitForNotification();
 
   // Should only show the middle strip (tile/0/1/0)
-  EXPECT_THAT(log, ::testing::UnorderedElementsAre(
-                      "set_starting", 
-                      "set_value: tile/0/1/0",
-                      "set_done", 
-                      "set_stopping"));
+  EXPECT_THAT(log, ::testing::UnorderedElementsAre("set_starting",
+                                                   "set_value: tile/0/1/0",
+                                                   "set_done", "set_stopping"));
 }
 
 }  // namespace

--- a/tensorstore/kvstore/tiff/tiff_test_util.cc
+++ b/tensorstore/kvstore/tiff/tiff_test_util.cc
@@ -147,7 +147,7 @@ std::string MakeTwoStripedTiff() {
              .AddUint32Array({4, 4})  // Strip byte counts
              .PadTo(200)
              .Build() +
-         "AAAA" + std::string(, '\0') + "BBBB";
+         "AAAA" + std::string(4, '\0') + "BBBB";
 }
 
 std::string MakeReadOpTiff() {

--- a/tensorstore/kvstore/tiff/tiff_test_util.cc
+++ b/tensorstore/kvstore/tiff/tiff_test_util.cc
@@ -1,0 +1,236 @@
+// Copyright 2025 The TensorStore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tensorstore/kvstore/tiff/tiff_test_util.h"
+
+namespace tensorstore {
+namespace internal_tiff_kvstore {
+namespace testing {
+
+TiffBuilder::TiffBuilder() {
+  // Standard TIFF header
+  data_ += "II";  // Little endian
+  data_.push_back(42);
+  data_.push_back(0);  // Magic number
+  data_.push_back(8);
+  data_.push_back(0);  // IFD offset (8)
+  data_.push_back(0);
+  data_.push_back(0);
+}
+
+TiffBuilder& TiffBuilder::StartIfd(uint16_t num_entries) {
+  data_.push_back(num_entries & 0xFF);
+  data_.push_back((num_entries >> 8) & 0xFF);
+  return *this;
+}
+
+TiffBuilder& TiffBuilder::AddEntry(uint16_t tag, uint16_t type, uint32_t count,
+                                   uint32_t value) {
+  data_.push_back(tag & 0xFF);
+  data_.push_back((tag >> 8) & 0xFF);
+  data_.push_back(type & 0xFF);
+  data_.push_back((type >> 8) & 0xFF);
+  data_.push_back(count & 0xFF);
+  data_.push_back((count >> 8) & 0xFF);
+  data_.push_back((count >> 16) & 0xFF);
+  data_.push_back((count >> 24) & 0xFF);
+  data_.push_back(value & 0xFF);
+  data_.push_back((value >> 8) & 0xFF);
+  data_.push_back((value >> 16) & 0xFF);
+  data_.push_back((value >> 24) & 0xFF);
+  return *this;
+}
+
+TiffBuilder& TiffBuilder::EndIfd(uint32_t next_ifd_offset) {
+  data_.push_back(next_ifd_offset & 0xFF);
+  data_.push_back((next_ifd_offset >> 8) & 0xFF);
+  data_.push_back((next_ifd_offset >> 16) & 0xFF);
+  data_.push_back((next_ifd_offset >> 24) & 0xFF);
+  return *this;
+}
+
+TiffBuilder& TiffBuilder::AddUint32Array(const std::vector<uint32_t>& values) {
+  for (uint32_t val : values) {
+    data_.push_back(val & 0xFF);
+    data_.push_back((val >> 8) & 0xFF);
+    data_.push_back((val >> 16) & 0xFF);
+    data_.push_back((val >> 24) & 0xFF);
+  }
+  return *this;
+}
+
+TiffBuilder& TiffBuilder::AddUint16Array(const std::vector<uint16_t>& values) {
+  for (uint16_t val : values) {
+    data_.push_back(val & 0xFF);
+    data_.push_back((val >> 8) & 0xFF);
+  }
+  return *this;
+}
+
+TiffBuilder& TiffBuilder::PadTo(size_t offset) {
+  while (data_.size() < offset) {
+    data_.push_back('X');
+  }
+  return *this;
+}
+
+std::string TiffBuilder::Build() const { return data_; }
+
+void PutLE16(std::string& dst, uint16_t v) {
+  dst.push_back(static_cast<char>(v & 0xff));
+  dst.push_back(static_cast<char>(v >> 8));
+}
+
+void PutLE32(std::string& dst, uint32_t v) {
+  dst.push_back(static_cast<char>(v & 0xff));
+  dst.push_back(static_cast<char>(v >> 8));
+  dst.push_back(static_cast<char>(v >> 16));
+  dst.push_back(static_cast<char>(v >> 24));
+}
+
+std::string MakeTinyTiledTiff() {
+  TiffBuilder builder;
+  return builder
+             .StartIfd(6)  // 6 entries
+             .AddEntry(256, 3, 1, 256)
+             .AddEntry(257, 3, 1, 256)  // width, length (256×256)
+             .AddEntry(322, 3, 1, 256)
+             .AddEntry(323, 3, 1, 256)  // tile width/length
+             .AddEntry(324, 4, 1, 128)
+             .AddEntry(325, 4, 1, 4)  // offset/bytecount
+             .EndIfd()                // next IFD
+             .PadTo(128)
+             .Build() +
+         "DATA";
+}
+
+std::string MakeTinyStripedTiff() {
+  TiffBuilder builder;
+  return builder
+             .StartIfd(5)               // 5 entries
+             .AddEntry(256, 3, 1, 4)    // ImageWidth = 4
+             .AddEntry(257, 3, 1, 8)    // ImageLength = 8
+             .AddEntry(278, 3, 1, 8)    // RowsPerStrip = 8
+             .AddEntry(273, 4, 1, 128)  // StripOffsets = 128
+             .AddEntry(279, 4, 1, 8)    // StripByteCounts = 8
+             .EndIfd()                  // No more IFDs
+             .PadTo(128)
+             .Build() +
+         "DATASTR!";
+}
+
+std::string MakeTwoStripedTiff() {
+  TiffBuilder builder;
+  return builder
+             .StartIfd(6)               // 6 entries
+             .AddEntry(256, 3, 1, 4)    // ImageWidth = 4
+             .AddEntry(257, 3, 1, 8)    // ImageLength = 8
+             .AddEntry(278, 3, 1, 4)    // RowsPerStrip = 4
+             .AddEntry(273, 4, 2, 128)  // StripOffsets array at offset 128
+             .AddEntry(279, 4, 2, 136)  // StripByteCounts array at offset 136
+             .AddEntry(259, 3, 1, 1)    // Compression = none
+             .EndIfd()                  // No more IFDs
+             .PadTo(128)
+             .AddUint32Array({200, 208})  // Strip offsets
+             .PadTo(136)
+             .AddUint32Array({4, 4})  // Strip byte counts
+             .PadTo(200)
+             .Build() +
+         "AAAA" + std::string(, '\0') + "BBBB";
+}
+
+std::string MakeReadOpTiff() {
+  TiffBuilder builder;
+  return builder
+             .StartIfd(6)  // 6 entries
+             .AddEntry(256, 3, 1, 16)
+             .AddEntry(257, 3, 1, 16)  // width, length
+             .AddEntry(322, 3, 1, 16)
+             .AddEntry(323, 3, 1, 16)  // tile width/length
+             .AddEntry(324, 4, 1, 128)
+             .AddEntry(325, 4, 1, 16)  // offset/bytecount
+             .EndIfd()                 // next IFD
+             .PadTo(128)
+             .Build() +
+         "abcdefghijklmnop";
+}
+
+std::string MakeMalformedTiff() {
+  std::string t;
+  t += "MM";  // Bad endianness (motorola instead of intel)
+  PutLE16(t, 42);
+  PutLE32(t, 8);  // header
+  PutLE16(t, 1);  // 1 IFD entry
+
+  // Helper lambda for creating an entry
+  auto E = [&](uint16_t tag, uint16_t type, uint32_t cnt, uint32_t val) {
+    PutLE16(t, tag);
+    PutLE16(t, type);
+    PutLE32(t, cnt);
+    PutLE32(t, val);
+  };
+
+  E(256, 3, 1, 16);  // Only width, missing other required tags
+  PutLE32(t, 0);     // next IFD
+  return t;
+}
+
+std::string MakeMultiIfdTiff() {
+  TiffBuilder builder;
+  return builder
+             .StartIfd(6)  // 6 entries for first IFD
+             .AddEntry(256, 3, 1, 256)
+             .AddEntry(257, 3, 1, 256)  // width, length (256×256)
+             .AddEntry(322, 3, 1, 256)
+             .AddEntry(323, 3, 1, 256)  // tile width/length
+             .AddEntry(324, 4, 1, 200)
+             .AddEntry(325, 4, 1, 5)  // offset/bytecount for IFD 0
+             .EndIfd(86)              // next IFD at offset 86
+             .PadTo(86)               // pad to second IFD
+             .StartIfd(6)             // 6 entries for second IFD
+             .AddEntry(256, 3, 1, 128)
+             .AddEntry(257, 3, 1, 128)  // width, length (128×128)
+             .AddEntry(322, 3, 1, 128)
+             .AddEntry(323, 3, 1, 128)  // tile width/length
+             .AddEntry(324, 4, 1, 208)
+             .AddEntry(325, 4, 1, 5)  // offset/bytecount for IFD 1
+             .EndIfd()                // No more IFDs
+             .PadTo(200)
+             .Build() +
+         "DATA1" + std::string(3, '\0') + "DATA2";
+}
+
+std::string MakeTiffMissingHeight() {
+  std::string t;
+  t += "II";  // Little endian
+  PutLE16(t, 42);
+  PutLE32(t, 8);  // header
+  PutLE16(t, 1);  // 1 IFD entry
+
+  // Helper lambda for creating an entry
+  auto E = [&](uint16_t tag, uint16_t type, uint32_t cnt, uint32_t val) {
+    PutLE16(t, tag);
+    PutLE16(t, type);
+    PutLE32(t, cnt);
+    PutLE32(t, val);
+  };
+
+  E(256, 3, 1, 16);  // Width but no Height
+  PutLE32(t, 0);     // next IFD
+  return t;
+}
+
+}  // namespace testing
+}  // namespace internal_tiff_kvstore
+}  // namespace tensorstore

--- a/tensorstore/kvstore/tiff/tiff_test_util.h
+++ b/tensorstore/kvstore/tiff/tiff_test_util.h
@@ -1,0 +1,81 @@
+// Copyright 2025 The TensorStore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENSORSTORE_KVSTORE_TIFF_TIFF_TEST_UTIL_H_
+#define TENSORSTORE_KVSTORE_TIFF_TIFF_TEST_UTIL_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace tensorstore {
+namespace internal_tiff_kvstore {
+namespace testing {
+
+// Helper class for building test TIFF files
+class TiffBuilder {
+ public:
+  TiffBuilder();
+
+  // Start an IFD with specified number of entries
+  TiffBuilder& StartIfd(uint16_t num_entries);
+
+  // Add an IFD entry
+  TiffBuilder& AddEntry(uint16_t tag, uint16_t type, uint32_t count,
+                        uint32_t value);
+
+  // End the current IFD and point to the next one at specified offset
+  // Use 0 for no next IFD
+  TiffBuilder& EndIfd(uint32_t next_ifd_offset = 0);
+
+  // Add external uint32_t array data
+  TiffBuilder& AddUint32Array(const std::vector<uint32_t>& values);
+
+  // Add external uint16_t array data
+  TiffBuilder& AddUint16Array(const std::vector<uint16_t>& values);
+
+  // Pad to a specific offset
+  TiffBuilder& PadTo(size_t offset);
+
+  // Get the final TIFF data
+  std::string Build() const;
+
+ private:
+  std::string data_;
+};
+
+// Little‑endian byte helper functions
+void PutLE16(std::string& dst, uint16_t v);
+void PutLE32(std::string& dst, uint32_t v);
+
+std::string MakeTinyTiledTiff();
+
+std::string MakeTinyStripedTiff();
+
+std::string MakeTwoStripedTiff();
+
+std::string MakeReadOpTiff();
+
+std::string MakeMalformedTiff();
+
+std::string MakeMultiIfdTiff();
+
+std::string MakeTiffMissingHeight();
+
+}  // namespace testing
+}  // namespace internal_tiff_kvstore
+}  // namespace tensorstore
+
+#endif  // TENSORSTORE_KVSTORE_TIFF_TIFF_TEST_UTIL_H_


### PR DESCRIPTION
This PR adds a new (read only) key-value store driver for accessing tiles and strips within TIFF image files. This is my second attempt after finding the time to work on this given previous feedback on #138. I drew heavily upon the zip kvstore implementation and your prior feedback (thanks!), so I hope that things are more faithful to Tensorstore patterns.

The basic idea is this kvstore sits on top of a base kvstore and maps IFDs/tiles/stripes to the following key format: `tile/<id>/<row>/<col>`. 

My plan is to get feedback on whether this something that is suitable to be merged. If I receive a positive response, I work on any feedback I receive in parallel with building out the tiff driver that will pair with this kvstore.

Looking forward to your feedback on this implementation! 