### PR TITLE
Update custom numeric data types to use default constructor

### DIFF
--- a/tensorstore/util/bfloat16.h
+++ b/tensorstore/util/bfloat16.h
@@ -79,10 +79,7 @@ float Bfloat16ToFloat(BFloat16 v);
 /// \ingroup Data types
 class BFloat16 {
  public:
-  /// Zero initialization.
-  ///
-  /// \id zero
-  constexpr BFloat16() : rep_(0) {}
+  BFloat16() = default;
 
   /// Possibly lossy conversion from any type convertible to `float`.
   ///

--- a/tensorstore/util/float8.h
+++ b/tensorstore/util/float8.h
@@ -85,8 +85,7 @@ class Float8Base {
 
  public:
   static constexpr int kBits = 8;
-
-  constexpr Float8Base() : rep_(0) {}
+  Float8Base() = default;
 
   template <typename T>
   explicit Float8Base(T i,

--- a/tensorstore/util/int2.h
+++ b/tensorstore/util/int2.h
@@ -48,10 +48,7 @@ constexpr int8_t SignedTrunc2(int8_t x) {
 /// \ingroup Data types
 class Int2Padded {
  public:
-  /// Zero initialization.
-  ///
-  /// \id zero
-  constexpr Int2Padded() : rep_(0) {}
+  Int2Padded() = default;
 
   /// Possibly lossy conversion from any type convertible to `int8_t`.
   ///

--- a/tensorstore/util/int4.h
+++ b/tensorstore/util/int4.h
@@ -49,10 +49,7 @@ constexpr int8_t SignedTrunc4(int8_t x) {
 /// \ingroup Data types
 class Int4Padded {
  public:
-  /// Zero initialization.
-  ///
-  /// \id zero
-  constexpr Int4Padded() : rep_(0) {}
+  Int4Padded() = default;
 
   /// Possibly lossy conversion from any type convertible to `int8_t`.
   ///


### PR DESCRIPTION
As discussed in https://github.com/google/tensorstore/issues/260, this change can improve performance by avoiding pre-filling buffers with zeros. This definitely improves performance and doesn't seem to cause any problems in the ad hoc tests that I've run, but I'm not sure if there are any edge cases or other places in the code where zero initialization is expected.