### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
           path: dist
           merge-multiple: true
       - name: Publish to PyPI (main server)
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4, always use commit hash
+        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # v1.13.0
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `pypa/gh-action-pypi-publish` | [`76f52bc`](https://github.com/pypa/gh-action-pypi-publish/commit/76f52bc884231f62b9a034ebfe128415bbaabdfc) | [`ec4db0b`](https://github.com/pypa/gh-action-pypi-publish/commit/ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0) | [Release](https://github.com/pypa/gh-action-pypi-publish/releases/tag/release/v1.9) | build.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
