### PR TITLE
Require Python 3.11 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ This invokes bazel via the included `bazelisk.py` wrapper script.
 
 import sys
 
-if sys.version_info < (3, 10):
-  print('Python >= 3.10 is required to build')
+if sys.version_info < (3, 11):
+  print('Python >= 3.11 is required to build')
   sys.exit(1)
 
 # Import setuptools before distutils because setuptools monkey patches


### PR DESCRIPTION
## Summary

- Update the explicit `setup.py` version guard to require Python 3.11.
- Correct the corresponding error message.

## Root cause

Python 3.10 support was removed in [`af2bd4f`](https://github.com/google/tensorstore/commit/af2bd4fd3aa58cfd442e92d3b0245581195eb79c), but the direct `setup.py` guard was not updated alongside `pyproject.toml`, the installation documentation, and wheel-building configuration.

## Impact

Direct `setup.py` invocations now reject unsupported Python 3.10 consistently with the project metadata and documentation. Supported Python versions are unaffected.

## Validation

- Python 3.10: `setup.py --name` reports `Python >= 3.11 is required to build` and exits with status 1.
- Python 3.11: `setup.py --name` reports `tensorstore` and exits successfully.
- `git diff --check`
- Bazel: 458 of 459 targets passed in the full sandboxed run with `--macos_minimum_os=10.13`; the remaining `//python/tensorstore:fork_test` then passed both tests directly using `/private/tmp` after the sandbox encountered a macOS privacy denial on its default temporary directory.

Fixes #292
